### PR TITLE
Fix Falldamage | Fix Switchweapon producing error in certain cases

### DIFF
--- a/lua/entities/npc_lambdaplayer.lua
+++ b/lua/entities/npc_lambdaplayer.lua
@@ -94,7 +94,7 @@ function ENT:Initialize()
         self.l_nextphysicsupdate = 0
         self.l_WeaponUseCooldown = 0
         self.l_currentnavarea = navmesh.GetNavArea( self:WorldSpaceCenter(), 400 )
-
+        self.l_FallVelocity = 0
 
         -- Personal Stats --
         

--- a/lua/lambdaplayers/lambda/sh_hooks.lua
+++ b/lua/lambdaplayers/lambda/sh_hooks.lua
@@ -188,14 +188,14 @@ if SERVER then
     
     function ENT:OnLandOnGround( ent )
         local damage = 0
-
+        
         if realisticfalldamage:GetBool() then
             damage = max( 0, ceil( 0.3218 * abs( self.l_FallVelocity ) - 153.75 ) )
         elseif abs( self.l_FallVelocity ) > 500 then
             damage = 10
         end
 
-        if damage > 0 and self:WaterLevel() > 0 then
+        if damage > 0 and self:WaterLevel() < 1 then
             local info = DamageInfo()
             info:SetDamage( damage )
             info:SetAttacker( Entity( 0 ) )

--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -236,7 +236,7 @@ function ENT:SwitchToRandomWeapon()
             return
         end
     end
-    self:SwitchWeapon( "NONE" )
+    self:SwitchWeapon( self.l_Weapon )
 end
 
 function ENT:SwitchToLethalWeapon()
@@ -247,5 +247,6 @@ function ENT:SwitchToLethalWeapon()
             return
         end
     end
-    self:SwitchWeapon( "NONE" )
+    -- Probably should make them panic if they can't equip a lethal weapon.
+    self:SwitchWeapon( self.l_Weapon )
 end

--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -247,6 +247,5 @@ function ENT:SwitchToLethalWeapon()
             return
         end
     end
-    -- Probably should make them panic if they can't equip a lethal weapon.
     self:SwitchWeapon( self.l_Weapon )
 end


### PR DESCRIPTION
- Fixed Falldamage not delivering damage outside of water.

- Fixed OnLandOnGround trying to use a nil value when the Lambda was spawned as they apparently land on ground when they spawn. Just added a self.l_FallVelocity = 0 in their init
![falldamage_onspawn](https://user-images.githubusercontent.com/9823203/201099067-cc329a4d-237e-4af0-a221-1f1fc7d51ed3.png)

- SwitchWeapon resulted in errors when Lambda tried to switch to another weapon, but didn't have any other weapon. Just replaced self:SwitchWeapon( "NONE" ) to self:SwitchWeapon( self.l_Weapon ) so they keep their own weapon if they didn't find anything else.
![switch_idle](https://user-images.githubusercontent.com/9823203/201099536-da8e9007-f8fb-4374-9aa7-56cfb9be7f31.png)
