### PR TITLE
Clean up of Tools | More tools randomly choose world or target | Documentation of Balloon

### DIFF
--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -116,7 +116,7 @@ local function UseBalloonTool( self, target )
     coroutine.wait( 1 ) -- We wait for a second
 
     -- Because we wait for 1 second we must make sure the target is still valid
-    if IsValid( trace.Entity ) and ( trace.Entity:GetClass() == "gmod_balloon" or !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return end
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) or trace.Entity:GetClass() == "gmod_balloon" then return end
 
     self:UseWeapon( trace.HitPos ) -- Use the toolgun on the hit position of the trace to fake using a tool
 
@@ -275,9 +275,7 @@ local function UseEmitterTool( self, target )
 
     coroutine.wait( 1 )
 
-    if IsValid( trace.Entity ) and ( trace.Entity:GetClass() == "gmod_emitter" or !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return end -- Check to avoid placing emitter on things they can't be attached to
-
-    -- We want to only weld to props
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) or trace.Entity:GetClass() == "gmod_emitter" then return end -- Check to avoid placing emitter on things they can't be attached to
 
     self:UseWeapon( trace.HitPos )
     local ent = CreateGmodEntity( "gmod_emitter", "models/props_lab/tpplug.mdl", trace.HitPos + trace.HitNormal, ang, self )
@@ -286,7 +284,7 @@ local function UseEmitterTool( self, target )
     self:ContributeEntToLimit( ent, "Emitter" )
     table_insert( self.l_SpawnedEntities, 1, ent )
 
-    if trace.Entity != NULL and !trace.Entity:IsWorld() then
+    if trace.Entity != NULL and !trace.Entity:IsWorld() then -- Only want to weld to props
         local weld = constraint.Weld( ent, trace.Entity, 0, trace.PhysicsBone, 0, true, true )
 
         if ( IsValid( ent:GetPhysicsObject() ) ) then ent:GetPhysicsObject():EnableCollisions( false ) end
@@ -319,7 +317,7 @@ local function UseHoverballTool( self, target )
     self:LookTo( trace.HitPos , 2 )
 
     coroutine.wait( 1 )
-    if IsValid( trace.Entity ) and ( trace.Entity:GetClass() == "gmod_hoverball" or !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return end -- Check to avoid placing hoverball on things they can't be attached to
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) or trace.Entity:GetClass() == "gmod_hoverball" then return end -- Check to avoid placing hoverball on things they can't be attached to
 
     local ang = trace.HitNormal:Angle()
     ang.pitch = ang.pitch + 90
@@ -466,7 +464,7 @@ local function UseLightTool( self, target )
 
     coroutine.wait( 1 )
 
-    if IsValid( trace.Entity ) and ( trace.Entity:GetClass() == "gmod_light" or !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) )  then return end -- Check to avoid placing light on things they can't be attached to
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) or trace.Entity:GetClass() == "gmod_light" then return end -- Check to avoid placing light on things they can't be attached to
 
     self:UseWeapon( trace.HitPos )
     local ent = CreateGmodEntity( "gmod_light", nil, trace.HitPos + trace.HitNormal * 8, trace.HitNormal:Angle() - Angle( 90, 0, 0 ), self ) -- Create the light
@@ -535,7 +533,7 @@ local function UsePaintTool( self, target )
 
     coroutine.wait( 1 )
 
-    if IsValid( trace.Entity ) and !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end
 
     local Pos1 = trace.HitPos + trace.HitNormal
     local Pos2 = trace.HitPos - trace.HitNormal
@@ -568,19 +566,15 @@ local physproperties = { "metal_bouncy", "metal", "dirt", "slipperyslime", "wood
 local function UsePhysPropTool( self, target )
     if !IsValid( target ) then return end
     
+    local trace = self:Trace( target:WorldSpaceCenter() )
     self:LookTo( target, 2 )
 
     coroutine.wait( 1 )
-    if !IsValid( target ) then return end
-
-    local trace = self:Trace( target:WorldSpaceCenter() )
-
-    local ent = trace.Entity
-    if !IsValid( ent ) or ent!=target then return end
+    if !IsValid( target ) or !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end -- it's pretty much a double IsValid but just in case
 
     self:UseWeapon( target:WorldSpaceCenter() )
 
-    construct.SetPhysProp( target:GetOwner(), ent, trace.PhysicsBone, nil, { GravityToggle = tobool( random( 0, 1 ) ), Material = physproperties[ random( #physproperties ) ] } ) -- Set the properties
+    construct.SetPhysProp( target:GetOwner(), trace.Entity, trace.PhysicsBone, nil, { GravityToggle = tobool( random( 0, 1 ) ), Material = physproperties[ random( #physproperties ) ] } ) -- Set the properties
 
     return true
 end
@@ -704,7 +698,7 @@ local function UseThrusterTool( self, target )
     self:LookTo( trace.HitPos, 2 )
 
     coroutine.wait( 1 )
-    if IsValid( trace.Entity ) and ( trace.Entity:GetClass() == "gmod_thruster" or !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return end -- Check to avoid placing thruster on things they can't be attached to
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) or trace.Entity:GetClass() == "gmod_thruster" then return end -- Check to avoid placing thruster on things they can't be attached to
 
     local ang = trace.HitNormal:Angle()
     ang.pitch = ang.pitch + 90
@@ -793,7 +787,7 @@ local function UseWheelTool( self, target )
 
     coroutine.wait( 1 )
 
-    if IsValid( trace.Entity ) and !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end
+    if !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end
 
     local mdl = wheelmodels[ random( #wheelmodels ) ]
     local wheelAngTab = list.Get( "WheelModels" )[mdl]

--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -6,6 +6,7 @@ local ColorRand = ColorRand
 local VectorRand = VectorRand
 local IsValid = IsValid
 local Round = math.Round
+local NormalizeAngle = math.NormalizeAngle
 local ents_Create = ents.Create
 local util_Effect = util.Effect
 local tobool = tobool
@@ -767,9 +768,7 @@ AddToolFunctionToLambdaTools( "Trail", UseTrailTool )
 
 
 
-local wheelmodels0 = { "models/props_vehicles/apc_tire001.mdl", "models/props_vehicles/tire001a_tractor.mdl", "models/props_vehicles/tire001b_truck.mdl", "models/props_vehicles/tire001c_car.mdl", "models/props_trainstation/trainstation_clock001.mdl", "models/props_c17/pulleywheels_large01.mdl" }
-local wheelmodels1 = { "models/props_junk/sawblade001a.mdl", "models/props_wasteland/controlroom_filecabinet002a.mdl", "models/props_borealis/bluebarrel001.mdl", "models/props_c17/oildrum001.mdl", "models/props_c17/playground_carousel01.mdl", "models/props_c17/chair_office01a.mdl", "models/props_c17/TrapPropeller_Blade.mdl", "models/props_junk/metal_paintcan001a.mdl" }
-local wheelmodels2 = { "models/props_vehicles/carparts_wheel01a.mdl", "models/props_wasteland/wheel01.mdl" }
+local wheelmodels = { "models/props_vehicles/apc_tire001.mdl", "models/props_vehicles/tire001a_tractor.mdl", "models/props_vehicles/tire001b_truck.mdl", "models/props_vehicles/tire001c_car.mdl", "models/props_trainstation/trainstation_clock001.mdl", "models/props_c17/pulleywheels_large01.mdl", "models/props_junk/sawblade001a.mdl", "models/props_wasteland/controlroom_filecabinet002a.mdl", "models/props_borealis/bluebarrel001.mdl", "models/props_c17/oildrum001.mdl", "models/props_c17/playground_carousel01.mdl", "models/props_c17/chair_office01a.mdl", "models/props_c17/TrapPropeller_Blade.mdl", "models/props_junk/metal_paintcan001a.mdl", "models/props_vehicles/carparts_wheel01a.mdl", "models/props_wasteland/wheel01.mdl" }
 local function UseWheelTool( self, target )
     if !self:IsUnderLimit( "Wheel" ) or !IsValid( target ) then return end
 
@@ -784,18 +783,9 @@ local function UseWheelTool( self, target )
 
     if IsValid( trace.Entity ) and !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end -- Check to avoid placing wheel on things they can't be attached to
 
-    -- TODO : Simplify this
-    local wheelrand = random( 0, 1 ) -- To deal with an angle issue...
-    local wheelAngle = Angle( math.NormalizeAngle( 90 ), math.NormalizeAngle( 0 ), math.NormalizeAngle( 90 ) )
-    local mdl = wheelmodels2[ random( #wheelmodels2 ) ]
-
-    if wheelrand==0 then
-        wheelAngle = Angle( math.NormalizeAngle( 0 ), math.NormalizeAngle( 0 ), math.NormalizeAngle( 0 ) )
-        mdl = wheelmodels0[ random( #wheelmodels0 ) ]
-    elseif wheelrand==1 then
-        wheelAngle = Angle( math.NormalizeAngle( 90 ), math.NormalizeAngle( 0 ), math.NormalizeAngle( 0 ) )
-        mdl = wheelmodels1[ random( #wheelmodels1 ) ]
-    end
+    local mdl = wheelmodels[ random( #wheelmodels ) ]
+    local wheelAngTab = list.Get( "WheelModels" )[mdl]
+    local wheelAngle = Angle( NormalizeAngle( wheelAngTab.wheel_rx ), NormalizeAngle( wheelAngTab.wheel_ry ), NormalizeAngle( wheelAngTab.wheel_rz ) )
     local torque = random( 10, 10000 )
 
     self:UseWeapon( target:WorldSpaceCenter() )
@@ -814,7 +804,7 @@ local function UseWheelTool( self, target )
     local LPos1 = ent:GetPhysicsObject():WorldToLocal( ent:GetPos() + trace.HitNormal )
     local LPos2 = targetPhys:WorldToLocal( trace.HitPos )
 
-    local const = constraint.Motor( ent, trace.Entity, 0, trace.PhysicsBone, LPos1, LPos2, random( 0, 100 ), torque, 0, random( 0, 1 ), 1 )
+    local const = constraint.Motor( ent, trace.Entity, 0, trace.PhysicsBone, LPos1, LPos2, random( 0, 100 ), torque, 0, tobool( random( 0, 1 ) ), 1 )
 
     ent:SetPos( trace.HitPos + wheelOffset )
     ent:SetPlayer( self )

--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -783,15 +783,11 @@ AddToolFunctionToLambdaTools( "Trail", UseTrailTool )
 local wheelmodels = { "models/props_vehicles/apc_tire001.mdl", "models/props_vehicles/tire001a_tractor.mdl", "models/props_vehicles/tire001b_truck.mdl", "models/props_vehicles/tire001c_car.mdl", "models/props_trainstation/trainstation_clock001.mdl", "models/props_c17/pulleywheels_large01.mdl", "models/props_junk/sawblade001a.mdl", "models/props_wasteland/controlroom_filecabinet002a.mdl", "models/props_borealis/bluebarrel001.mdl", "models/props_c17/oildrum001.mdl", "models/props_c17/playground_carousel01.mdl", "models/props_c17/chair_office01a.mdl", "models/props_c17/TrapPropeller_Blade.mdl", "models/props_junk/metal_paintcan001a.mdl", "models/props_vehicles/carparts_wheel01a.mdl", "models/props_wasteland/wheel01.mdl" }
 local function UseWheelTool( self, target )
     if !self:IsUnderLimit( "Wheel" ) then return end
-
-    -- TODO : Randomly choose between world or target
-
     local world = random( 0, 1 )
+
     if !world and !IsValid( target ) then return end
 
     local trace = world and self:Trace( self:WorldSpaceCenter() + VectorRand( -12600, 12600 ) ) or self:Trace( target:WorldSpaceCenter() )
-
-    -- -- --
 
     self:LookTo( trace.HitPos , 2 )
 
@@ -819,10 +815,10 @@ local function UseWheelTool( self, target )
     local targetPhys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
     local LPos1 = ent:GetPhysicsObject():WorldToLocal( ent:GetPos() + trace.HitNormal )
     local LPos2 = targetPhys:WorldToLocal( trace.HitPos )
+    ent:SetPos( trace.HitPos + wheelOffset )
 
     local const = constraint.Motor( ent, trace.Entity, 0, trace.PhysicsBone, LPos1, LPos2, random( 0, 100 ), torque, 0, random( 0, 1 ), 1 )
 
-    ent:SetPos( trace.HitPos + wheelOffset )
     ent:SetPlayer( self )
     ent:SetMotor( const )
     ent:SetDirection( const.direction )

--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -247,6 +247,19 @@ AddToolFunctionToLambdaTools( "Dynamite", UseDynamiteTool )
 
 
 
+local ropematerials = { "cable/redlaser", "cable/cable2", "cable/rope", "cable/blue_elec", "cable/xbeam", "cable/physbeam", "cable/hydra" }
+--[[local function UseElasticTool( self, target )
+
+    -- TODO
+
+    return true
+end
+AddToolFunctionToLambdaTools( "Elastic", UseElasticTool )]]
+
+
+
+
+
 local effectlist = { "manhacksparks", "glassimpact", "striderblood", "shells", "cball_explode", "ar2impact", "bloodimpact", "sparks", "dirtywatersplash", "watersplash", "stunstickimpact", "thumperdust", "muzzleeffect", "bloodspray", "helicoptermegabomb", "rifleshells", "ar2explosion", "explosion", "cball_bounce", "shotgunshells", "underwaterexplosion", "smoke" }
 local function UseEmitterTool( self, target )
     if !self:IsUnderLimit( "Emitter" ) then return end
@@ -608,7 +621,6 @@ AddToolFunctionToLambdaTools( "Remover", UseRemoverTool )
 
 
 
-local ropematerials = { "cable/redlaser", "cable/cable2", "cable/rope", "cable/blue_elec", "cable/xbeam", "cable/physbeam", "cable/hydra" }
 local function UseRopeTool( self, target )
     if !self:IsUnderLimit( "Rope" ) then return end
 
@@ -770,25 +782,29 @@ AddToolFunctionToLambdaTools( "Trail", UseTrailTool )
 
 local wheelmodels = { "models/props_vehicles/apc_tire001.mdl", "models/props_vehicles/tire001a_tractor.mdl", "models/props_vehicles/tire001b_truck.mdl", "models/props_vehicles/tire001c_car.mdl", "models/props_trainstation/trainstation_clock001.mdl", "models/props_c17/pulleywheels_large01.mdl", "models/props_junk/sawblade001a.mdl", "models/props_wasteland/controlroom_filecabinet002a.mdl", "models/props_borealis/bluebarrel001.mdl", "models/props_c17/oildrum001.mdl", "models/props_c17/playground_carousel01.mdl", "models/props_c17/chair_office01a.mdl", "models/props_c17/TrapPropeller_Blade.mdl", "models/props_junk/metal_paintcan001a.mdl", "models/props_vehicles/carparts_wheel01a.mdl", "models/props_wasteland/wheel01.mdl" }
 local function UseWheelTool( self, target )
-    if !self:IsUnderLimit( "Wheel" ) or !IsValid( target ) then return end
+    if !self:IsUnderLimit( "Wheel" ) then return end
 
     -- TODO : Randomly choose between world or target
 
-    self:LookTo( target, 2 )
+    local world = random( 0, 1 )
+    if !world and !IsValid( target ) then return end
+
+    local trace = world and self:Trace( self:WorldSpaceCenter() + VectorRand( -12600, 12600 ) ) or self:Trace( target:WorldSpaceCenter() )
+
+    -- -- --
+
+    self:LookTo( trace.HitPos , 2 )
 
     coroutine.wait( 1 )
-    if !IsValid( target ) then return end
 
-    local trace = self:Trace( target:WorldSpaceCenter() )
-
-    if IsValid( trace.Entity ) and !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end -- Check to avoid placing wheel on things they can't be attached to
+    if IsValid( trace.Entity ) and !util_IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end
 
     local mdl = wheelmodels[ random( #wheelmodels ) ]
     local wheelAngTab = list.Get( "WheelModels" )[mdl]
     local wheelAngle = Angle( NormalizeAngle( wheelAngTab.wheel_rx ), NormalizeAngle( wheelAngTab.wheel_ry ), NormalizeAngle( wheelAngTab.wheel_rz ) )
     local torque = random( 10, 10000 )
 
-    self:UseWeapon( target:WorldSpaceCenter() )
+    self:UseWeapon( trace.HitPos )
     local ent = CreateGmodEntity( "gmod_wheel", mdl, trace.HitPos, trace.HitNormal:Angle() + wheelAngle, self )
     ent.LambdaOwner = self
     ent.IsLambdaSpawned = true
@@ -804,7 +820,7 @@ local function UseWheelTool( self, target )
     local LPos1 = ent:GetPhysicsObject():WorldToLocal( ent:GetPos() + trace.HitNormal )
     local LPos2 = targetPhys:WorldToLocal( trace.HitPos )
 
-    local const = constraint.Motor( ent, trace.Entity, 0, trace.PhysicsBone, LPos1, LPos2, random( 0, 100 ), torque, 0, tobool( random( 0, 1 ) ), 1 )
+    local const = constraint.Motor( ent, trace.Entity, 0, trace.PhysicsBone, LPos1, LPos2, random( 0, 100 ), torque, 0, random( 0, 1 ), 1 )
 
     ent:SetPos( trace.HitPos + wheelOffset )
     ent:SetPlayer( self )


### PR DESCRIPTION
A lot of things got changed in the tools file

- With the Balloon Tool being the first tool you now see in the file, documented the hell out of it to be a good example.
- Made more tools able to "decide" between a target or the world.
- Reused the variables in the trace table instead of declaring new variables like pos or hitentity. Personal preference here.
- Simplified Wheel Tool angle and model variables. Thanks garry.


There was something else but apparently github removed half my description...