### PR TITLE
Tweaks & bugfixes for weapons

### DIFF
--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -43,6 +43,8 @@ function ENT:SwitchWeapon( weaponname, forceswitch )
         else
             wepent.l_killiconname = killicon_
         end
+    else
+        wepent.l_killiconname = nil
     end
 
     

--- a/lua/lambdaplayers/lambda/weapons/css_knife.lua
+++ b/lua/lambdaplayers/lambda/weapons/css_knife.lua
@@ -1,8 +1,6 @@
 local random = math.random
 local CurTime = CurTime
-local firstSwing = true
-local firstSwingTime = 0
-local convar = CreateLambdaConvar( "lambdaplayers_weapons_knifebackstab", 1, true, false, true, "If Lambda Players should be allowed to use the backstab feature of the Knife.", 0, 1, { type = "Bool", name = "Knife - Enable Backstab", category = "Weapon Utilities" } )
+local backstabCvar = CreateLambdaConvar( "lambdaplayers_weapons_knifebackstab", 1, true, false, true, "If Lambda Players should be allowed to use the backstab feature of the Knife.", 0, 1, { type = "Bool", name = "Knife - Enable Backstab", category = "Weapon Utilities" } )
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -15,52 +13,54 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         bonemerge = true,
         keepdistance = 10,
         attackrange = 50,
-        
+
         OnEquip = function( lambda, wepent )
+            wepent.IsFirstSwing = true
+            wepent.NextFirstSwingTime = CurTime()
             wepent:EmitSound( "Weapon_Knife.Deploy" )
         end,
 
-        callback = function( self, wepent, target )
-            local backstabCheck = self:WorldToLocalAngles( target:GetAngles() + Angle( 0, -90, 0 ) )
-            local backstabConVar = GetConVar( "lambdaplayers_weapons_knifebackstab" ):GetBool()
+        OnUnequip = function( lambda, wepent )
+            wepent.IsFirstSwing = nil
+            wepent.NextFirstSwingTime = nil
+        end,
 
-            if CurTime() > firstSwingTime then
-                firstSwing = true
+        callback = function( self, wepent, target )
+            if CurTime() > wepent.NextFirstSwingTime then
+                wepent.IsFirstSwing = true
             end
-            
-            self.l_WeaponUseCooldown = CurTime() + 0.5
-            firstSwingTime = self.l_WeaponUseCooldown + 0.4
-            
-            local isBackstab = false
-            local dmg = ( firstSwing and 20 or 15 )
 
             self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_KNIFE )
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_KNIFE )
-            
-            wepent:EmitSound( "Weapon_Knife.Slash" )
-            if backstabCheck.y < -30 and backstabCheck.y > -140 and backstabConVar then
-                isBackstab = true
-                dmg = 195
-                target:EmitSound( "weapons/knife/knife_stab.wav", 70 )
+
+            local slashSnd = "Weapon_Knife.Hit"
+            local slashDmg = ( wepent.IsFirstSwing and 20 or 15 )
+            if backstabCvar:GetBool() then
+                local backstabCheck = self:WorldToLocalAngles( target:GetAngles() + Angle( 0, -90, 0 ) ).y
+                if backstabCheck < -30 and backstabCheck > -140 then
+                    slashDmg = 195
+                    slashSnd = "Weapon_Knife.Stab"
+                end
             end
 
             local dmginfo = DamageInfo() 
-            dmginfo:SetDamage( dmg )
+            dmginfo:SetDamage( slashDmg )
             dmginfo:SetAttacker( self )
             dmginfo:SetInflictor( wepent )
             dmginfo:SetDamageType( DMG_SLASH )
-            dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * dmg )
-
-            self.l_WeaponUseCooldown = CurTime() + ( isBackstab and 1.0 or 0.5 )
-            target:EmitSound( "Weapon_Knife.Hit", 70 )
-
+            dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * slashDmg )
             target:TakeDamageInfo( dmginfo )
-            firstSwing = false
-            
+
+            wepent:EmitSound( slashSnd )
+            self.l_WeaponUseCooldown = CurTime() + ( slashDmg == 195 and 1.0 or 0.5 )
+
+            wepent.IsFirstSwing = false
+            wepent.NextFirstSwingTime = self.l_WeaponUseCooldown + 0.4
+
             return true
         end,
 
-        islethal = true,
+        islethal = true
     }
 
 })

--- a/lua/lambdaplayers/lambda/weapons/fists.lua
+++ b/lua/lambdaplayers/lambda/weapons/fists.lua
@@ -1,9 +1,8 @@
+local IsValid = IsValid
 local random = math.random
 local math_min = math.min
 local CurTime = CurTime
 local Rand = math.Rand
-local fistCombo = 0
-local fistComboTime = 0
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -12,27 +11,29 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         origin = "Garry's Mod",
         prettyname = "Fists",
         holdtype = "fist",
-        killicon = "lambdaplayers/killicons/icon_fist",
+        killicon = "lambdaplayers/killicons/icon_fists",
         ismelee = true,
         nodraw = true,
         keepdistance = 15,
         attackrange = 45,
         
         OnEquip = function( lambda, wepent )
+            wepent.FistCombo = 0
+            wepent.FistComboTime = CurTime()
+        end,
 
-        end,
-        
         OnUnequip = function( lambda, wepent )
-           
+            wepent.FistCombo = nil
+            wepent.FistComboTime = nil
         end,
-        
+
         callback = function( self, wepent, target )
-            if CurTime() > fistComboTime then
-                fistCombo = 0
+            if CurTime() > wepent.FistComboTime then
+                wepent.FistCombo = 0
             end
 
             self.l_WeaponUseCooldown = CurTime() + 0.9
-            fistComboTime = self.l_WeaponUseCooldown + 0.1
+            wepent.FistComboTime = self.l_WeaponUseCooldown + 0.1
 
             wepent:EmitSound( "WeaponFrag.Throw", 70 )
 
@@ -40,32 +41,34 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_FIST )
             
             self:SimpleTimer( 0.2, function()
-                if self:GetRangeSquaredTo( target ) > ( 45 * 45 ) then return end
-                
-                local dmg = random( 8, 12 )
-                if fistCombo >= 2 then 
-                    dmg = random( 12, 24 )
-                    fistCombo = -1
-                end
+                if !IsValid( target ) or self:GetRangeSquaredTo( target ) > ( 45 * 45 ) then return end
 
                 local dmginfo = DamageInfo()
-                dmginfo:SetDamage( dmg )
                 dmginfo:SetAttacker( self )
                 dmginfo:SetInflictor( wepent )
-                dmginfo:SetDamageType( DMG_SLASH )
-                dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * dmg )
                 
-                wepent:EmitSound( "Flesh.ImpactHard", 70 )
-
-                fistCombo = fistCombo + 1
+                local attackDmg = random( 8, 12 )
+                local attackAng = ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):Angle()
+                local attackForce = ( attackAng:Up() * 4912 + attackAng:Forward() * 9989 )
+                if wepent.FistCombo >= 2 then
+                    attackDmg = random( 12, 24 )
+                    attackForce = ( attackAng:Up() * 5158 + attackAng:Forward() * 10012 )
+                    wepent.FistCombo = 0
+                else
+                    wepent.FistCombo = wepent.FistCombo + 1
+                    if random( 2 ) == 1 then attackForce = ( attackAng:Up() * -4912 + attackAng:Forward() * 9989 ) end
+                end
+                dmginfo:SetDamage( attackDmg )
+                dmginfo:SetDamageForce( attackForce )
                 
                 target:TakeDamageInfo( dmginfo )
+                wepent:EmitSound( "Flesh.ImpactHard", 70 )
             end)
-            
+
             return true
         end,
         
-        islethal = true,
+        islethal = true
     }
 
 })

--- a/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
@@ -1,4 +1,7 @@
+local IsValid = IsValid
 local CurTime = CurTime
+local util_BlastDamage = util.BlastDamage
+local ents_Create = ents.Create
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 --Missing guided rockets
@@ -13,33 +16,50 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         keepdistance = 800,
         attackrange = 5000,
 
+        OnEquip = function( lambda, wepent )
+            wepent.CurrentRocket = NULL
+            lambda:Hook( "Think", "LambdaPlayer_OnlyOneRPGRocket", function()
+                if !IsValid( wepent.CurrentRocket ) then return end
+                lambda.l_WeaponUseCooldown = CurTime() + 2.0
+            end, false )
+        end,
+
+        OnUnequip = function( lambda, wepent )
+            wepent.CurrentRocket = nil
+            lambda:RemoveHook( "Think", "LambdaPlayer_OnlyOneRPGRocket" )
+        end,
+
         callback = function( self, wepent, target )            
-            self.l_WeaponUseCooldown = CurTime() + 3
+            local rocket = ents_Create( "rpg_missile" )
+            if !IsValid( rocket ) then return end
+
+            self.l_WeaponUseCooldown = CurTime() + 2.0
 
             wepent:EmitSound( "Weapon_RPG.Single" )
 
             self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_RPG )
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_RPG )
 
-            local rocket = ents.Create( "rpg_missile" )
-            if IsValid( rocket ) then
-                rocket:SetPos( wepent:GetAttachment(2).Pos + wepent:GetAttachment(2).Ang:Forward() * 100 + Vector(0,0,15) )
-                rocket:SetAngles( ( target:WorldSpaceCenter() - wepent:GetPos() ):Angle() )
-                rocket:SetOwner( self )
-                rocket:SetCollisionGroup( COLLISION_GROUP_DEBRIS )-- SetOwner should prevent collision but it doesn't
-                rocket:Spawn()
-                
-                self:SimpleTimer( 0.3, function()-- Grace period to avoid collision with the shooter
-                    if !IsValid( rocket ) then return false end
-                    rocket:SetCollisionGroup( COLLISION_GROUP_PROJECTILE )
-                end)
+            local spawnAttach = wepent:GetAttachment(2)
+            local targetAng = ( target:WorldSpaceCenter() - wepent:GetPos() ):Angle()
+            rocket:SetPos( spawnAttach.Pos + targetAng:Forward() * 100 + targetAng:Up() * 15 )
+            rocket:SetAngles( ( target:WorldSpaceCenter() - rocket:GetPos() ):Angle() )
+            rocket:SetOwner( self )
+            rocket:SetCollisionGroup( COLLISION_GROUP_DEBRIS ) -- SetOwner should prevent collision but it doesn't
+            rocket:Spawn()
 
-                rocket:CallOnRemove( "lambdaplayer_rpgrocket_"..rocket:EntIndex(), function()
-                    rocket:StopSound( "weapons/rpg/rocket1.wav" )--Trying to prevent source being dumb
-                    util.BlastDamage( rocket, (self:IsValid()) and self or rocket, rocket:GetPos(), 260, 210)
-                end)
-            end
-            
+            self:SimpleTimer( 0.3, function() -- Grace period to avoid collision with the shooter
+                if !IsValid( rocket ) then return end
+                rocket:SetCollisionGroup( COLLISION_GROUP_PROJECTILE )
+            end)
+
+            rocket:CallOnRemove( "LambdaPlayer_RPGRocket_" .. rocket:EntIndex(), function()
+                rocket:StopSound( "weapons/rpg/rocket1.wav" ) -- Trying to prevent source being dumb
+                util_BlastDamage( rocket, ( IsValid( self ) and self or rocket ), rocket:GetPos(), 260, 210)
+            end)
+
+            wepent.CurrentRocket = rocket
+
             return true
         end,
 

--- a/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
@@ -1,6 +1,12 @@
 local CurTime = CurTime
 local random = math.random
-local bullettbl = {}
+local bulletData = {
+    Damage = 8,
+    Force = 8,
+    HullSize = 5,
+    TracerName = "Tracer",
+    Spread = Vector( 0.1, 0.1, 0 )
+}
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -24,47 +30,35 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             if self.l_Clip <= 0 then self:ReloadWeapon() return end
 
             -- Secondary double barrel attack
-            if random( 8 ) == 1 and self.l_Clip >= 2 and self:GetRangeSquaredTo( target ) <= ( 400 * 400 ) then
+            if self.l_Clip >= 2 and random( 8 ) == 1 and self:GetRangeSquaredTo( target ) <= ( 400 * 400 ) then
                 self.l_WeaponUseCooldown = CurTime() + random( 1.2, 1.5 )
-
                 wepent:EmitSound( "Weapon_Shotgun.Double" )
-
-                bullettbl.Num = 12
-
+                bulletData.Num = 12
                 self.l_Clip = self.l_Clip - 2
             else
                 self.l_WeaponUseCooldown = CurTime() + random( 1, 1.25 )
-
                 wepent:EmitSound( "Weapon_Shotgun.Single" )
-
-                bullettbl.Num = 7
-
+                bulletData.Num = 7
                 self.l_Clip = self.l_Clip - 1
             end
-            
-            bullettbl.Attacker = self
-            bullettbl.Damage = 8
-            bullettbl.Force = 8
-            bullettbl.HullSize = 5
-            bullettbl.TracerName = tracer or "Tracer"
-            bullettbl.Dir = ( target:WorldSpaceCenter() - wepent:GetPos() ):GetNormalized()
-            bullettbl.Src = wepent:GetPos()
-            bullettbl.Spread = Vector( 0.1, 0.1, 0 )
-            bullettbl.IgnoreEntity = self
+
+            self:HandleMuzzleFlash( 1 )
+
+            bulletData.Attacker = self
+            bulletData.IgnoreEntity = self
+            bulletData.Src = wepent:GetPos()
+            bulletData.Dir = ( target:WorldSpaceCenter() - wepent:GetPos() ):GetNormalized()
+            wepent:FireBullets( bulletData )
 
             self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_SHOTGUN )
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_SHOTGUN )
             
-            self:HandleMuzzleFlash( 1 )
-
-            wepent:FireBullets( bullettbl )
-
             -- To simulate pump action after the shot
             self:SimpleTimer( 0.6, function()
                 wepent:EmitSound( "Weapon_Shotgun.Special1", 70, 100, 1, CHAN_WEAPON )
-                self:HandleShellEject( "ShotgunShellEject", Vector( 0, 12, 0 ), Angle( -180 , 0, 0 ) )
+                self:HandleShellEject( "ShotgunShellEject", Vector( 0, 12, 0 ), Angle( -180, 0, 0 ) )
             end)
-            
+
             return true
         end,
 

--- a/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
@@ -1,5 +1,7 @@
+local IsValid = IsValid
 local CurTime = CurTime
 local random = math.random
+local RandAngle = AngleRand
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -20,8 +22,8 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         rateoffire = 0.075,
         muzzleflash = 1,
         shelleject = "ShellEject",
-        shelloffpos = Vector(3,5,5),
-        shelloffang = Angle(-180,0,0),
+        shelloffpos = Vector( 3, 5, 5 ),
+        shelloffang = Angle( -180, 0, 0 ),
         attackanim = ACT_HL2MP_GESTURE_RANGE_ATTACK_SMG1,
         attacksnd = "Weapon_SMG1.Single",
 
@@ -32,25 +34,25 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         callback = function( self, wepent, target )
             -- Secondary grenade launcher
-            if random( 75 ) == 1 and self:GetRangeSquaredTo( target ) <= ( 1000 * 1000 ) then
-                local grenade = ents.Create( "grenade_ar2" )
-                if IsValid( grenade ) then
-                    wepent:EmitSound( "Weapon_SMG1.Double" )
-                    
-                    self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_RPG )
-                    self.l_WeaponUseCooldown = CurTime() + 0.5
+            if random( 75 ) != 1 or self:GetRangeSquaredTo( target ) > ( 1000 * 1000 ) then return end
+            
+            local grenade = ents.Create( "grenade_ar2" )
+            if !IsValid( grenade ) then return end
 
-                    local vecThrow = ( target:WorldSpaceCenter() - self:EyePos() ):Angle()
-                    grenade:SetPos( self:EyePos() + vecThrow:Forward() * 32 + vecThrow:Up() * 32 )
-                    grenade:SetAngles( vecThrow )
-                    grenade:SetOwner( self )
-                    grenade:Spawn()
-                    grenade:SetVelocity( vecThrow:Forward() * 1000 )
-                    grenade:SetLocalAngularVelocity( AngleRand( -400, 400 ) )
-                    
-                    return true
-                end
-            end
+            self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_RPG )
+            self.l_WeaponUseCooldown = CurTime() + 0.5
+
+            wepent:EmitSound( "Weapon_SMG1.Double" )
+
+            grenade:SetPos( self:EyePos() + vecThrow:Forward() * 32 + vecThrow:Up() * 32 )
+            local vecThrow = ( target:WorldSpaceCenter() - grenade:GetPos() ):Angle()
+            grenade:SetAngles( vecThrow )
+            grenade:SetOwner( self )
+            grenade:Spawn()
+            grenade:SetVelocity( vecThrow:Forward() * 1000 )
+            grenade:SetLocalAngularVelocity( RandAngle( -400, 400 ) )
+
+            return true
         end,
 
         islethal = true,

--- a/lua/lambdaplayers/lambda/weapons/misc_meathook.lua
+++ b/lua/lambdaplayers/lambda/weapons/misc_meathook.lua
@@ -1,3 +1,4 @@
+local IsValid = IsValid
 local random = math.random
 local CurTime = CurTime
 local Rand = math.Rand
@@ -23,20 +24,19 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_MELEE2 )
             
             self:SimpleTimer( 0.3, function()
-                if self:GetRangeSquaredTo( target ) > ( 65 * 65 ) then return end
-                
-                local dmg = random( 40,50 )
+                if !IsValid( target ) or self:GetRangeSquaredTo( target ) > ( 65 * 65 ) then return end
+
+                local dmg = random( 40, 50 )
                 local dmginfo = DamageInfo()
                 dmginfo:SetDamage( dmg )
                 dmginfo:SetAttacker( self )
                 dmginfo:SetInflictor( wepent )
                 dmginfo:SetDamageType( DMG_SLASH )
                 dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * dmg )
-                
-                target:EmitSound( "lambdaplayers/weapons/meathook/hook-"..random(3)..".mp3", 70 )
-                
                 target:TakeDamageInfo( dmginfo )
-            end)
+
+                target:EmitSound( "lambdaplayers/weapons/meathook/hook-" .. random(3) .. ".mp3", 70 )
+            end )
             
             return true
         end,

--- a/lua/lambdaplayers/lambda/weapons/misc_shovel.lua
+++ b/lua/lambdaplayers/lambda/weapons/misc_shovel.lua
@@ -1,3 +1,4 @@
+local IsValid = IsValid
 local random = math.random
 local CurTime = CurTime
 local Rand = math.Rand
@@ -16,15 +17,15 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         attackrange = 70,
                 
         callback = function( self, wepent, target )
-            self.l_WeaponUseCooldown = CurTime() + Rand(0.8, 0.95)
+            self.l_WeaponUseCooldown = CurTime() + Rand( 0.8, 0.95 )
 
             wepent:EmitSound( "npc/zombie/claw_miss1.wav", 70, 100, 1, CHAN_WEAPON )
             self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_MELEE2 )
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_MELEE2 )
             
             self:SimpleTimer( 0.3, function()
-                if self:GetRangeSquaredTo( target ) > ( 70 * 70 ) then return end
-                
+                if !IsValid( target ) or self:GetRangeSquaredTo( target ) > ( 70 * 70 ) then return end
+
                 local dmg = random( 25,30 )
                 local dmginfo = DamageInfo()
                 dmginfo:SetDamage( dmg )
@@ -32,13 +33,12 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
                 dmginfo:SetInflictor( wepent )
                 dmginfo:SetDamageType( DMG_CLUB )
                 dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * dmg )
-                
-                wepent:EmitSound( "physics/metal/metal_sheet_impact_hard"..random(6,7)..".wav", 70 )
-                wepent:EmitSound( "physics/body/body_medium_impact_hard"..random(6)..".wav", 70 )
-                
                 target:TakeDamageInfo( dmginfo )
-            end)
-            
+
+                wepent:EmitSound( "physics/metal/metal_sheet_impact_hard" .. random( 6, 7 ) .. ".wav", 70 )
+                wepent:EmitSound( "physics/body/body_medium_impact_hard" .. random( 6 ) .. ".wav", 70 )
+            end )
+
             return true
         end,
 

--- a/lua/lambdaplayers/lambda/weapons/misc_volver.lua
+++ b/lua/lambdaplayers/lambda/weapons/misc_volver.lua
@@ -2,7 +2,15 @@ local random = math.random
 local CurTime = CurTime
 local IsValid = IsValid
 local util_Effect = util.Effect
-local bullettbl = {}
+local util_ScreenShake = util.ScreenShake
+local bulletData = {
+    Damage = 1000,
+    Force = 1000,
+    HullSize = 5,
+    Num = 1,
+    TracerName = "GunshipTracer",
+    Spread = Vector( 0.05, 0.05, 0 )
+}
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -18,52 +26,46 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         callback = function( self, wepent, target )
             self.l_WeaponUseCooldown = CurTime() + 5
-
             wepent:EmitSound( "weapons/pistol/pistol_empty.wav", 70, 100, 1, CHAN_WEAPON )
 
             self:SimpleTimer( 1, function()
-                if !IsValid( self ) or !IsValid( target ) or !IsValid( wepent ) then return end
+                if self.l_Weapon != "volver" or !IsValid( wepent ) then return end
+
                 wepent:EmitSound( "weapons/357/357_fire2.wav", 70, random( 70, 75 ), 1, CHAN_WEAPON )
                 self:EmitSound( "ambient/explosions/explode_4.wav", 70, 100, 1, CHAN_WEAPON )
-                self:EmitSound( "physics/body/body_medium_break"..math.random( 2, 4 )..".wav", 90)
-
-                local attach = wepent:GetAttachment( 1 )
+                self:EmitSound( "physics/body/body_medium_break" .. random( 2, 4 ) .. ".wav", 90 )
 
                 self:HandleMuzzleFlash( 7 )
 
-                util.ScreenShake( self:GetPos(), 10, 170, 3, 1500 )
+                local attach = wepent:GetAttachment( 1 )
+                local effData = EffectData()
+                    effData:SetOrigin( attach.Pos )
+                    effData:SetStart( attach.Pos )
+                    effData:SetAngles( attach.Ang )
+                    effData:SetMagnitude( 5 )
+                    effData:SetScale( 10 )
+                    effData:SetRadius( 10 )
+                util_Effect( "cball_bounce", effData, true, true )
 
-                local effect = EffectData()
-                    effect:SetOrigin( attach.Pos )
-                    effect:SetStart( attach.Pos )
-                    effect:SetAngles( attach.Ang )
-                    effect:SetMagnitude( 5 )
-                    effect:SetScale( 10 )
-                    effect:SetRadius( 10 )
-                util_Effect( "cball_bounce", effect, true, true )
+                util_ScreenShake( self:GetPos(), 10, 170, 3, 1500 )
 
-                bullettbl.Attacker = self
-                bullettbl.Damage = 1000
-                bullettbl.Force = 1000
-                bullettbl.HullSize = 5
-                bullettbl.Num = 1
-                bullettbl.TracerName = "GunshipTracer"
-                bullettbl.Dir = ( target:WorldSpaceCenter() - wepent:GetPos() ):GetNormalized()
-                bullettbl.Src = wepent:GetPos()
-                bullettbl.Spread = Vector( 0.05, 0.05, 0 )
-                bullettbl.IgnoreEntity = self
-                
-                wepent:FireBullets( bullettbl )
+                local shootDir = ( ( IsValid( target ) and target:WorldSpaceCenter() or self:GetEyeTrace().HitPos ) - wepent:GetPos() ):GetNormalized()
 
-                local dmg = DamageInfo()
-                dmg:SetDamage( self:Health() * 100000 )
-                dmg:SetDamageType( DMG_BLAST ) 
-                dmg:SetAttacker( self )
-                dmg:SetInflictor( self )
-                dmg:SetDamageForce( self:GetForward() * -80000000 )
-                self:TakeDamageInfo( dmg )
+                bulletData.Dir = shootDir
+                bulletData.Attacker = self
+                bulletData.IgnoreEntity = self
+                bulletData.Src = wepent:GetPos()
+                wepent:FireBullets( bulletData )
+
+                local dmginfo = DamageInfo()
+                dmginfo:SetDamage( self:Health() * 100000 )
+                dmginfo:SetDamageType( DMG_BLAST ) 
+                dmginfo:SetAttacker( self )
+                dmginfo:SetInflictor( self )
+                dmginfo:SetDamageForce( shootDir * -80000000 )
+                self:TakeDamageInfo( dmginfo )
             end)
-            
+
             return true
         end,
 

--- a/lua/lambdaplayers/lambda/weapons/misc_zombieclaws.lua
+++ b/lua/lambdaplayers/lambda/weapons/misc_zombieclaws.lua
@@ -4,7 +4,7 @@ local CurTime = CurTime
 local Rand = math.Rand
 local IsValid = IsValid
 local math_sqrt = math.sqrt
-local NextLeapAttack = 0.5
+local PlaySound = sound.Play
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -19,55 +19,59 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         keepdistance = 10,
         attackrange = 75,
         addspeed = 100,
-        
+
         -- HP Auto Regen + Leap Attack
         OnEquip = function( lambda, wepent )
+            wepent.NextLeapAttackTime = CurTime()
+
             lambda:Hook( "Think", "ZombieClawsThink", function( )
                 if lambda:Health() < lambda:GetMaxHealth() then
                     lambda:SetHealth( math_min( lambda:Health() + 1, lambda:GetMaxHealth() ) )
                 end
 
-                if NextLeapAttack and CurTime() > NextLeapAttack then
+                if lambda:GetState() == "Combat" and CurTime() > wepent.NextLeapAttackTime then
                     local target = lambda:GetEnemy()
-                    if IsValid( target ) then
+                    if LambdaIsValid( target ) then
                         local distTarget = lambda:GetRangeSquaredTo( target )
-                        if distTarget > ( 300 * 300 ) and distTarget <= ( 600 * 600 ) and lambda.loco:IsOnGround() and target:Visible( lambda ) then
+                        if distTarget > ( 300 * 300 ) and distTarget <= ( 600 * 600 ) and lambda.loco:IsOnGround() and lambda:Visible( target ) and target:Visible( lambda ) then
                             lambda.loco:Jump()
 
-                            local jumpDir = ( target:GetPos() - lambda:GetPos() ):GetNormalized()
-                            lambda.loco:SetVelocity( Vector( 0, 0, 400 ) + jumpDir * math_min( math_sqrt( distTarget ) * 0.4, 512))
+                            local jumpDir = ( target:GetPos() - lambda:GetPos() ):Angle()
+                            lambda.loco:SetVelocity( jumpDir:Up() * 400 + jumpDir:Forward() * math_min( math_sqrt( distTarget ) * 1.5, 1024 ) )
 
-                            lambda:EmitSound( "npc/fast_zombie/fz_scream1.wav", 80, lambda.VoicePitch)
-                            NextLeapAttack = CurTime() + 5
+                            lambda:EmitSound( "npc/fast_zombie/fz_scream1.wav", 80, lambda:GetVoicePitch() )
+                            wepent.NextLeapAttackTime = CurTime() + 5
                         end
                     end
                 end
-            end, nil, 0.5)
+            end, false, 0.5)
         end,
 
         -- Damage reduction
         OnDamage = function( lambda, wepent, dmginfo )
-            if IsValid( lambda ) then
-                dmginfo:ScaleDamage( 0.75 )
-            end
+            dmginfo:ScaleDamage( 0.75 )
         end,
-        
+
         OnUnequip = function( lambda, wepent )
             lambda:RemoveHook( "Think", "ZombieClawsThink" )
+            wepent.NextLeapAttackTime = nil
         end,
-        
+
         callback = function( self, wepent, target )
             self.l_WeaponUseCooldown = CurTime() + 1.25
+            self:EmitSound( "npc/zombie/zo_attack" .. random(2) .. ".wav", 70, self:GetVoicePitch(), 1, CHAN_WEAPON )
 
-            wepent:EmitSound( "npc/zombie/zo_attack"..random(2)..".wav", 70, self.VoicePitch, 1, CHAN_WEAPON )
-            
             self:RemoveGesture( ACT_GMOD_GESTURE_RANGE_ZOMBIE )
-            self:AddGesture( ACT_GMOD_GESTURE_RANGE_ZOMBIE )
-            
+            local attackAnim = self:AddGesture( ACT_GMOD_GESTURE_RANGE_ZOMBIE )
+            self:SetLayerPlaybackRate( attackAnim, 1.5 ) -- Sped up attack animation
+
             -- To make sure damage syncs with the animation
-            self:SimpleTimer( 0.75, function()
-                if self:GetRangeSquaredTo( target ) > ( 65 * 65 ) then wepent:EmitSound("npc/zombie/claw_miss"..random(2)..".wav", 70) return end
-                
+            self:SimpleTimer( 0.5, function()
+                if !LambdaIsValid( target ) or self:GetRangeSquaredTo( target ) > ( 65 * 65 ) then 
+                    wepent:EmitSound( "Zombie.AttackMiss" ) 
+                    return 
+                end
+
                 local dmg = random( 35, 55 )
                 local dmginfo = DamageInfo()
                 dmginfo:SetDamage( dmg )
@@ -75,17 +79,18 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
                 dmginfo:SetInflictor( wepent )
                 dmginfo:SetDamageType( DMG_SLASH )
                 dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * dmg )
-                
-                target:EmitSound( "npc/zombie/claw_strike"..random(3)..".wav", 70)
-                
-                -- HP regen on attacks
-                if self:Health() < self:GetMaxHealth() * 2.25 and LambdaIsValid( target ) then
-                    self:SetHealth( math_min( self:Health() + self:GetMaxHealth() * Rand( 0.10, 0.20 ), self:GetMaxHealth() * 2.25 ) )
-                end
-                
+
+                local targetPrevHP = target:Health()
                 target:TakeDamageInfo( dmginfo )
+                PlaySound( "Zombie.AttackHit", target:WorldSpaceCenter() )
+
+                -- Steal target's HP on successful hit
+                local maxHP = self:GetMaxHealth() * 2.25
+                if target:Health() < targetPrevHP and self:Health() < maxHP then
+                    self:SetHealth( math_min( self:Health() + ( targetPrevHP - target:Health() ), maxHP ) )
+                end
             end)
-            
+
             return true
         end,
         


### PR DESCRIPTION
 - Increased Zombie Claws' attack animation speed and tweaked the leap velocity;
 - Lambdas will not fire RPG until the currently launched missile explodes;
 - Fixed typo on Fists' killicon path;
 - Some local variables used in functions were converted to weapon entity's variable to avoid conflicts with multiple weapons using the same variable;
 - Fixed weapon using a killicon of the previously switched weapon.