### PR TITLE
Faceposer tool | Less world welds | More paint | Prettied up holster and changed some vars name

### DIFF
--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -654,7 +654,7 @@ AddToolFunctionToLambdaTools( "Material", UseMaterialTool )
 
 
 
-local decallist = { "Eye", "Dark", "Smile", "Cross", "Nought", "Noughtsncrosses" } -- Keeping it simple for now
+local decallist = { "Eye", "Dark", "Smile", "Cross", "Nought", "Noughtsncrosses", "Light", "Blood", "YellowBlood", "Impact.Metal", "Scorch", "BeerSplash", "ExplosiveGunshot", "BirdPoop", "PaintSplatPink", "PaintSplatGreen", "PaintSplatBlue", "ManhackCut", "FadingScorch", "Antlion.Splat", "Splash.Large", "BulletProof", "GlassBreak", "Impact.Sand", "Impact.BloodyFlesh", "Impact.Antlion", "Impact.Glass", "Impact.Wood", "Impact.Concrete" }
 local function UsePaintTool( self, target )
     local world = random( 0, 1 )
     if !world and !IsValid( target ) then return end

--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -401,6 +401,34 @@ AddToolFunctionToLambdaTools( "Emitter", UseEmitterTool )
 
 
 
+local function UseFaceposerTool( self, target )
+    if !IsValid( target ) or target:GetClass() != "prop_ragdoll" then return end
+    
+    local trace = self:Trace( target:WorldSpaceCenter() )
+    local entity = trace.Entity
+    local physbone = trace.PhysicsBone
+    self:LookTo( target, 2 )
+
+    coroutine.wait( 1 )
+    if !IsValid( target ) or !util_IsValidPhysicsObject( entity, physbone ) then return end -- it's pretty much a double IsValid but just in case
+
+    self:UseWeapon( target:WorldSpaceCenter() )
+
+    for i = 0, target:GetFlexNum()-1 do
+        if random( 4 ) > 1 then -- 25% chance to not edit a flex, to add a bit of randomness to that
+            target:SetFlexWeight(i, math.random()*math.random(5))
+        end
+    end
+
+    return true
+end
+AddToolFunctionToLambdaTools( "Faceposer", UseFaceposerTool )
+
+
+
+
+
+
 local hoverballmodels = { "models/dav0r/hoverball.mdl", "models/maxofs2d/hover_basic.mdl", "models/maxofs2d/hover_classic.mdl", "models/maxofs2d/hover_plate.mdl", "models/maxofs2d/hover_propeller.mdl", "models/maxofs2d/hover_rings.mdl" }
 local function UseHoverballTool( self, target )
     if !self:IsUnderLimit( "Hoverball" ) then return end
@@ -602,6 +630,8 @@ local function UseLightTool( self, target )
     return true
 end
 AddToolFunctionToLambdaTools( "Light", UseLightTool )
+
+
 
 
 
@@ -941,7 +971,7 @@ AddToolFunctionToLambdaTools( "Trail", UseTrailTool )
 local function UseWeldTool( self, target )
     if !IsValid( target ) then return end
 
-    local world = random( 0, 1 )
+    local world = random( 5 ) == 1 --To avoid welding to the world too much by default
     local find = self:FindInSphere( nil, 800, function( ent ) if ent != target and !ent:IsNPC() and !ent:IsPlayer() and !ent:IsNextBot() and self:CanSee( ent ) and IsValid( ent:GetPhysicsObject() ) and self:HasPermissionToEdit( ent ) then return true end end )
     local target2 = find[ random( #find ) ]
 
@@ -980,7 +1010,6 @@ local function UseWeldTool( self, target )
     return true
 end
 AddToolFunctionToLambdaTools( "Weld", UseWeldTool )
-
 
 
 

--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -93,7 +93,7 @@ local function DefaultRangedWeaponFire( self, wepent, target, weapondata, disabl
     
     if !disabletbl.sound then wepent:EmitSound( TranslateRandomization( weapondata.attacksnd ), 70, 100, 1, CHAN_WEAPON ) end
     
-    if !disabletbl.muzzleflash then self:HandleMuzzleFlash( weapondata.muzzleflash, weapondata.muzzleflashpos, weapondata.muzzleflashang ) end
+    if !disabletbl.muzzleflash then self:HandleMuzzleFlash( weapondata.muzzleflash, weapondata.muzzleoffpos, weapondata.muzzleoffang ) end
     if !disabletbl.shell then self:HandleShellEject( weapondata.shelleject, weapondata.shelloffpos, weapondata.shelloffang ) end
 
     if !disabletbl.anim then
@@ -181,7 +181,7 @@ function ENT:ReloadWeapon()
     local wep = self:GetWeaponENT()
     local time = weapondata.reloadtime or 1
     local anim = weapondata.reloadanim
-    local animspeed = weapondata.reloadanimationspeed or 1
+    local animspeed = weapondata.reloadanimspeed or 1
     local snds = weapondata.reloadsounds
 
     if snds and #snds > 0 then

--- a/lua/lambdaplayers/lambda/weapons/gravitygun.lua
+++ b/lua/lambdaplayers/lambda/weapons/gravitygun.lua
@@ -4,7 +4,7 @@ local IsValid = IsValid
 local util_Effect = util.Effect
 local tracetbl = {}
 
--- Effects idle gravity gun
+-- Effects for gravity gun idle
 local ggunGlowSprite = Material("sprites/glow04_noz")
 
 -- Effects for pulling and grabbing active

--- a/lua/lambdaplayers/lambda/weapons/hl2_ar2.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_ar2.lua
@@ -28,7 +28,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         reloadtime = 1.5,
         reloadanim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        reloadanimationspeed = 1,
+        reloadanimspeed = 1,
         reloadsounds = { 
             { 0, "Weapon_AR2.Reload_Rotate" },
             { 0.63, "Weapon_AR2.Reload_Push" }

--- a/lua/lambdaplayers/lambda/weapons/hl2_revolver.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_revolver.lua
@@ -22,7 +22,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         reloadtime = 3.66,
         --reloadanim = ACT_HL2MP_GESTURE_RELOAD_REVOLVER,
-        reloadanimationspeed = 1,
+        reloadanimspeed = 1,
         reloadsounds = { 
             { 0.933, "Weapon_357.OpenLoader" }, 
             { 1.3, "Weapon_357.RemoveLoader" }, 

--- a/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
@@ -24,7 +24,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         reloadtime = 3,
         reloadanim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
-        reloadanimationspeed = 1,
+        reloadanimspeed = 1,
 
         callback = function( self, wepent, target )
             if self.l_Clip <= 0 then self:ReloadWeapon() return end

--- a/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
@@ -29,7 +29,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         reloadtime = 1.5,
         reloadanim = ACT_HL2MP_GESTURE_RELOAD_SMG1,
-        reloadanimationspeed = 1,
+        reloadanimspeed = 1,
         reloadsounds = { { 0, "Weapon_SMG1.Reload" } },
 
         callback = function( self, wepent, target )

--- a/lua/lambdaplayers/lambda/weapons/hl2_usppistol.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_usppistol.lua
@@ -23,7 +23,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         reloadtime = 1.8,
         reloadanim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
-        reloadanimationspeed = 1,
+        reloadanimspeed = 1,
         reloadsounds = { { 0, "Weapon_Pistol.Reload" } },
 
         islethal = true,

--- a/lua/lambdaplayers/lambda/weapons/holster.lua
+++ b/lua/lambdaplayers/lambda/weapons/holster.lua
@@ -3,84 +3,82 @@
 
     VALID WEAPON SETTINGS
 
-    Var name | TYPE | Description
+    Var name        | TYPE |        Description
 
 
     --- Possible Melee settings ---
 
-    model | String | The model of the weapon
-    prettyname | String | The name that will show in settings and ect
-    origin | String | The game or whatever the weapon originates from
-    killicon | String | The file path to a material ( without the file extension ) to use as the kill icon for this weapon or the alias name of a existing kill icon, example weapon_ar2 is a existing kill icon
-    nodraw | Bool | If the weapon should not draw
-    islethal | Bool | If the weapon is capable of hurting anything
-    holdtype | String | The animation set Lambda should use. See globals.lua and the _LAMBDAPLAYERSHoldTypeAnimations table
-    ismelee | Bool | If the weapon is considered a melee weapon. False for ranged
-    offpos | Vector | The offset position of the weapon local to the Lambda's considered hand position
-    offang | Angle | The offset angle of the weapon local to the Lambda
+    model           | String |      The model of the weapon
+    prettyname      | String |      The name that will show in settings and ect
+    origin          | String |      The game or whatever the weapon originates from
+    killicon        | String |      The file path to a material ( without the file extension ) to use as the kill icon for this weapon or the alias name of a existing kill icon, example weapon_ar2 is a existing kill icon
+    nodraw          | Bool |        If the weapon should not draw
+    islethal        | Bool |        If the weapon is capable of hurting anything
+    holdtype        | String |      The animation set Lambda should use. See globals.lua and the _LAMBDAPLAYERSHoldTypeAnimations table
+    ismelee         | Bool |        If the weapon is considered a melee weapon. False for ranged
+    offpos          | Vector |      The offset position of the weapon local to the Lambda's considered hand position
+    offang          | Angle |       The offset angle of the weapon local to the Lambda
 
-    addspeed | Number | The amount to add to speed while in combat
-    keepdistance | Number | The distance the Lambda will keep from the target
-    attackrange | Number | The range the Lambda can attack from
-    damage  | Number | The amount of damage the weapon can deal
-    rateoffire | Number | How fast the weapon is fired/used
-    attackanim | Number | The ACT Gesture to play when used
+    addspeed        | Number |      The amount to add to speed while in combat
+    keepdistance    | Number |      The distance the Lambda will keep from the target
+    attackrange     | Number |      The range the Lambda can attack from
+    damage          | Number |      The amount of damage the weapon can deal
+    rateoffire      | Number |      How fast the weapon is fired/used
+    attackanim      | Number |      The ACT Gesture to play when used
 
-    OnDamage | Function | A function that will be called when the Lambda Player is hurt while holding this weapon
-    Draw | Function | A Client side function that allows you to make render effects in 3d space
-    callback | function | A function that will be called when the weapon is used. Return true if you are making a custom shooting/swinging code
-    OnEquip | function | A function that will be called when the weapon is equipped
-    OnUnequip | function | a function that will be called when the weapon is unequipped
-
+    OnDamage        | Function |    A function that will be called when the Lambda Player is hurt while holding this weapon
+    Draw            | Function |    A client side function that allows you to make render effects in 3d space
+    callback        | Function |    A function that will be called when the weapon is used. Return true if you are making a custom shooting/swinging code
+    OnEquip         | Function |    A function that will be called when the weapon is equipped
+    OnUnequip       | Function |    A function that will be called when the weapon is unequipped
 
 
 
     ---------------------------------
 
 
+
     --- Possible Ranged Settings ---
-    model | String | The model of the weapon
-    prettyname | String | The name that will show in settings and ect
-    origin | String | The game or whatever the weapon originates from
-    killicon | String | The file path to a material ( without the file extension ) to use as the kill icon for this weapon or the alias name of a existing kill icon, example weapon_ar2 is a existing kill icon
-    nodraw | Bool | If the weapon should not draw
-    islethal | Bool | If the weapon is capable of hurting anything
-    holdtype | String | The animation set Lambda should use. See autorun_includes/server/globals.lua and the _LAMBDAPLAYERSHoldTypeAnimations table
-    ismelee | Bool | If the weapon is considered a melee weapon. False for ranged
-    offpos | Vector | The offset position of the weapon local to the Lambda's considered hand position
-    offang | Angle | The offset angle of the weapon local to the Lambda
+    model           | String |      The model of the weapon
+    prettyname      | String |      The name that will show in settings and ect
+    origin          | String |      The game or whatever the weapon originates from
+    killicon        | String |      The file path to a material ( without the file extension ) to use as the kill icon for this weapon or the alias name of a existing kill icon, example weapon_ar2 is a existing kill icon
+    nodraw          | Bool |        If the weapon should not draw
+    islethal        | Bool |        If the weapon is capable of hurting anything
+    holdtype        | String |      The animation set Lambda should use. See autorun_includes/server/globals.lua and the _LAMBDAPLAYERSHoldTypeAnimations table
+    ismelee         | Bool |        If the weapon is considered a melee weapon. False for ranged
+    offpos          | Vector |      The offset position of the weapon local to the Lambda's considered hand position
+    offang          | Angle |       The offset angle of the weapon local to the Lambda
 
-    addspeed | Number | The amount to add to speed while in combat
-    keepdistance | Number | The distance the Lambda will keep from the target
-    attackrange | Number | The range the Lambda can attack from
-    damage  | Number | The amount of damage the weapon can deal
-    rateoffire | Number | How fast the weapon is fired/used
-    attackanim | Number | The ACT Gesture to play when used
-    bulletcount | Number | The amount of bullets to fire when used
-    tracername | String | Tracer name. Valid entries are Tracer, AR2Tracer, LaserTracer, AirboatGunHeavyTracer, and ToolTracer
-    clip | Number | The amount of times the weapon can be shot before reloading.
+    addspeed        | Number |      The amount to add to speed while in combat
+    keepdistance    | Number |      The distance the Lambda will keep from the target
+    attackrange     | Number |      The range the Lambda can attack from
+    damage          | Number |      The amount of damage the weapon can deal
+    rateoffire      | Number |      How fast the weapon is fired/used
+    attackanim      | Number |      The ACT Gesture to play when used
+    bulletcount     | Number |      The amount of bullets to fire when used
+    tracername      | String |      Tracer name. Valid entries are Tracer, AR2Tracer, LaserTracer, AirboatGunHeavyTracer, and ToolTracer
+    clip            | Number |      The amount of times the weapon can be shot before reloading.
 
-    OnDamage | Function | A function that will be called when the Lambda Player is hurt while holding this weapon
-    Draw | Function | A Client side function that allows you to make render effects in 3d space
-    callback | function | A function that will be called when the weapon is used. Return true if you are making a custom shooting/swinging code
-    OnEquip | function | A function that will be called when the weapon is equipped
-    OnUnequip | function | a function that will be called when the weapon is unequipped
+    muzzleflash     | Number |      The muzzle flash type. 1 = Regular 5 = Combine 7 = Regular but bigger
+    muzzleoffpos    | Vector |      The offset postion of the muzzleflash local to the weapon
+    muzzleoffang    | Angle |       The offset angle of the muzzleflash local to the weapon
 
+    shelleject      | String |      Shell type valid types are ShellEject, RifleShellEject, ShotgunShellEject
+    shelloffpos     | Vector |      The offset postion of the shell eject local to the weapon
+    shelloffang     | Angle |       The offset angles of the shell eject local to the weapon
 
-    muzzleflash | Number | The muzzle flash type. 1 = Regular 5 = Combine 7 = Regular but bigger
-    muzzleflashpos | Vector | The offset postion of the muzzleflash local to the weapon
-    muzzleflashang | Angle | The offset angle of the muzzleflash local to the weapon
-
-    shelleject | String | Shell type valid types are ShellEject, RifleShellEject, ShotgunShellEject
-    shelloffpos | Vector | The offset postion of the shell eject local to the weapon
-    shelloffang | Angle | The offset angles of the shell eject local to the weapon
-            
-
-    reloadtime | Number | The time it takes to reload
-    reloadanim | Number | Reload Gesture animation
-    reloadanimationspeed | Number | The speed of the reload animation
-    reloadsounds | Table | A table of tables that each have their 1 index as the time the sound will play and the 2 index being the sound path. Example reloadsounds = { { 0.5, "somesound1" }, { 1, "somesound2" } }
-    OnReload | Function | A function that will be called when the weapon's reload is started
+    reloadtime      | Number |      The time it takes to reload
+    reloadanim      | Number |      Reload Gesture animation
+    reloadanimspeed | Number |      The speed of the reload animation
+    reloadsounds    | Table |       A table of tables that each have their 1 index as the time the sound will play and the 2 index being the sound path. Example reloadsounds = { { 0.5, "somesound1" }, { 1, "somesound2" } }
+   
+    OnDamage        | Function |    A function that will be called when the Lambda Player is hurt while holding this weapon
+    Draw            | Function |    A client side function that allows you to make render effects in 3d space
+    callback        | Function |    A function that will be called when the weapon is used. Return true if you are making a custom shooting/swinging code
+    OnEquip         | Function |    A function that will be called when the weapon is equipped
+    OnUnequip       | Function |    A function that will be called when the weapon is unequipped
+    OnReload        | Function |    A function that will be called when the weapon's reload is started
 
     ---------------------------------
 ]]


### PR DESCRIPTION
### This following PR changes the following weapon variables to fit the writing convention of other variables
reloadanimationspeed to reloadanimspeed
muzzleflashpos to muzzleoffpos
muzzleflashang to muzzleoffang

Also adds the Faceposer tool, makes world welds less likely to happen by default, more Paint tool choices and makes the holster documentation more breathable.
