### PR TITLE
Minor changes to weapons and Creator tool

### DIFF
--- a/lua/lambdaplayers/autorun_includes/client/spawnmenu.lua
+++ b/lua/lambdaplayers/autorun_includes/client/spawnmenu.lua
@@ -16,7 +16,7 @@ local epiccontributors = [[
 Special thanks to the following Contributors
 
 :- CombineSlayer24
-:- Floofers
+:- Fluffiest Floofers
 :- YerMash
 
 Your contributions are appreciated!

--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -235,7 +235,11 @@ AddToolFunctionToLambdaTools( "Color", UseColorTool )
 
 
 
+
+
 local function UseCreatorTool( self, target )
+    local allowpropCvar = GetConVar( "lambdaplayers_building_allowprop" ):GetBool()
+    if !self:IsUnderLimit( "Prop" ) or !allowpropCvar then return end
 
     local pos = self:Trace( self:WorldSpaceCenter() + VectorRand( -12600, 12600 ) )
     pos = pos.HitPos

--- a/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/lambda_toolguntools.lua
@@ -466,7 +466,6 @@ AddToolFunctionToLambdaTools( "Faceposer", UseFaceposerTool )
 
 
 
-
 local hoverballmodels = { "models/dav0r/hoverball.mdl", "models/maxofs2d/hover_basic.mdl", "models/maxofs2d/hover_classic.mdl", "models/maxofs2d/hover_plate.mdl", "models/maxofs2d/hover_propeller.mdl", "models/maxofs2d/hover_rings.mdl" }
 local function UseHoverballTool( self, target )
     if !self:IsUnderLimit( "Hoverball" ) then return end

--- a/lua/lambdaplayers/lambda/panels/profilepanel.lua
+++ b/lua/lambdaplayers/lambda/panels/profilepanel.lua
@@ -227,7 +227,7 @@ local function OpenProfilePanel( ply )
     LAMBDAPANELS:CreateLabel( "materials/lambdaplayers/custom_profilepictures", mainscroll, TOP )
     LAMBDAPANELS:CreateLabel( "Leave Blank for random", mainscroll, TOP )
     LAMBDAPANELS:CreateURLLabel( "Click here to learn about Profile Pictures", "https://github.com/IcyStarFrost/Lambda-Players#profile-pictures", mainscroll, TOP )
-    local profilepicture = LAMBDAPANELS:CreateTextEntry( mainscroll, TOP, "Enter a model path" )
+    local profilepicture = LAMBDAPANELS:CreateTextEntry( mainscroll, TOP, "Enter a file path" )
 
     local pfppreview = vgui.Create( "DImage", mainscroll )
     pfppreview:SetSize( 100, 150 )

--- a/lua/lambdaplayers/lambda/weapons/css_knife.lua
+++ b/lua/lambdaplayers/lambda/weapons/css_knife.lua
@@ -6,7 +6,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     knife = {
         model = "models/weapons/w_knife_t.mdl",
-        origin = "Counter Strike: Source",
+        origin = "Counter-Strike: Source",
         prettyname = "Knife",
         holdtype = "knife",
         ismelee = true,

--- a/lua/lambdaplayers/lambda/weapons/hl2_ar2.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_ar2.lua
@@ -9,7 +9,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     ar2 = {
         model = "models/weapons/w_irifle.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "AR2",
         holdtype = "ar2",
         killicon = "weapon_ar2",

--- a/lua/lambdaplayers/lambda/weapons/hl2_bugbait.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_bugbait.lua
@@ -12,7 +12,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     bugbait = {
         model = "models/weapons/w_bugbait.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Bug Bait",
         holdtype = "grenade",
         bonemerge = true,

--- a/lua/lambdaplayers/lambda/weapons/hl2_crossbow.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_crossbow.lua
@@ -5,7 +5,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     crossbow = {
         model = "models/weapons/w_crossbow.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Crossbow",
         holdtype = "crossbow",
         killicon = "crossbow_bolt",

--- a/lua/lambdaplayers/lambda/weapons/hl2_crowbar.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_crowbar.lua
@@ -2,7 +2,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     crowbar = {
         model = "models/weapons/w_crowbar.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Crowbar",
         holdtype = "melee",
         killicon = "weapon_crowbar",

--- a/lua/lambdaplayers/lambda/weapons/hl2_gravitygun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_gravitygun.lua
@@ -20,7 +20,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     gravgun = {
         model = "models/weapons/w_physics.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Gravity Gun",
         killicon = "weapon_physcannon", -- No idea if this is needed but why not
         bonemerge = true,

--- a/lua/lambdaplayers/lambda/weapons/hl2_grenade.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_grenade.lua
@@ -7,7 +7,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     grenade = {
         model = "models/weapons/w_grenade.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Grenade",
         holdtype = "grenade",
         killicon = "npc_grenade_frag",

--- a/lua/lambdaplayers/lambda/weapons/hl2_revolver.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_revolver.lua
@@ -4,7 +4,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     revolver = {
         model = "models/weapons/w_357.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = ".357 Revolver",
         holdtype = "revolver",
         killicon = "weapon_357",

--- a/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
@@ -8,7 +8,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     rpg = {
         model = "models/weapons/w_rocket_launcher.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "RPG",
         holdtype = "rpg",
         killicon = "rpg_missile",

--- a/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
@@ -12,7 +12,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     shotgun = {
         model = "models/weapons/w_shotgun.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "SPAS 12",
         holdtype = "shotgun",
         killicon = "weapon_shotgun",

--- a/lua/lambdaplayers/lambda/weapons/hl2_slam.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_slam.lua
@@ -12,7 +12,7 @@ local EntityCreate = ents.Create
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
     slam = {
         model = "models/weapons/w_slam.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "S.L.A.M",
         holdtype = "slam",
         killicon = "npc_satchel",

--- a/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
@@ -7,7 +7,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     smg = {
         model = "models/weapons/w_smg1.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "SMG",
         killicon = "weapon_smg1",
         holdtype = "smg",

--- a/lua/lambdaplayers/lambda/weapons/hl2_stunstick.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_stunstick.lua
@@ -7,7 +7,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     stunstick = {
         model = "models/weapons/w_stunbaton.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Stunstick",
         holdtype = "melee",
         killicon = "weapon_stunstick",

--- a/lua/lambdaplayers/lambda/weapons/hl2_usppistol.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_usppistol.lua
@@ -2,7 +2,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
     pistol = {
         model = "models/weapons/w_pistol.mdl",
-        origin = "Half Life: 2",
+        origin = "Half-Life 2",
         prettyname = "Pistol",
         holdtype = "pistol",
         killicon = "weapon_pistol",

--- a/lua/lambdaplayers/lambda/weapons/physicsgun.lua
+++ b/lua/lambdaplayers/lambda/weapons/physicsgun.lua
@@ -14,6 +14,7 @@ local max = math.max
 local render = render or nil
 local trace = {}
 
+local aidisable = GetConVar( "ai_disabled" )
 local allowphysgunuse = GetConVar( "lambdaplayers_lambda_allowphysgunpickup" )
 
 --[[ local function CreatePhysgunBeam( owner )
@@ -104,7 +105,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
                 lambda:Thread( function()
 
                     while true do 
-                        if lambda:GetState() == "Idle" and !physgunactive and random( 1, 3 ) == 1 then
+                        if lambda:GetState() == "Idle" and !physgunactive and random( 1, 3 ) == 1 and !aidisable:GetBool() then
                             local possibleents = lambda:FindInSphere( nil, 1500, function( ent ) return !ignoreentclasses[ ent:GetClass() ] and lambda:HasVPhysics( ent ) and lambda:HasPermissionToEdit( ent ) and lambda:CanSee( ent ) end )
                             local ent = possibleents[ random( #possibleents ) ]
 


### PR DESCRIPTION
- Changed origin names for CSS and HL2 weapons.
- Fixed Creator Tool bypassing prop limit and the allow prop spawning cvar.
- Changed default text of the profile picture in the profile panel from "Enter a model path" to "Enter a file path".
- Disabled the ability for Lambdas to physgun things around if their AI was disabled.