### PR TITLE
Ladder Climbing | Basic VJ Base Support

### DIFF
--- a/lua/entities/npc_lambdaplayer.lua
+++ b/lua/entities/npc_lambdaplayer.lua
@@ -118,6 +118,8 @@ function ENT:Initialize()
         self.l_unstuck = false -- If true, runs our unstuck process
         self.l_recomputepath = nil -- If set to true, recompute the current path. After that this will reset to nil
         self.l_UpdateAnimations = true -- If we can update our animations. Used for the purpose of playing sequences
+        self.l_ClimbingLadder = false -- If we are currenly climbing a ladder
+        self.VJ_AddEntityToSNPCAttackList = true -- Makes creature-based VJ SNPCs able to damages us with melee and leap attacks
 
         self.l_UnstuckBounds = 50 -- The distance the unstuck process will use to check. This value increments during the process and set back to 50 when done
         self.l_nextspeedupdate = 0 -- The next time we update our speed

--- a/lua/lambdaplayers/lambda/sh_hooks.lua
+++ b/lua/lambdaplayers/lambda/sh_hooks.lua
@@ -53,6 +53,7 @@ if SERVER then
         
         self:PlaySoundFile( deathdir:GetString() == "randomengine" and self:GetRandomSound() or self:GetVoiceLine( "death" ) )
 
+        self:SetHealth( -1 ) -- SNPCs will think that we are still alive without doing this.
         self:SetIsDead( true )
         self:SetNoClip( false )
         self:SetCollisionGroup( COLLISION_GROUP_IN_VEHICLE )
@@ -184,6 +185,20 @@ if SERVER then
             self:TakeDamageInfo( dmginfo )  
     
             collider:EmitSound( "NPC_CombineBall.KillImpact" )
+        elseif collider.CustomOnDoDamage_Direct then -- Makes VJ projectiles able to do direct damages to us.
+            local owner = collider:GetOwner()
+            local dmgPos = ( data and data.HitPos or collider:GetPos() )
+
+            collider:CustomOnDoDamage_Direct( data, data.HitObject, self )
+            
+            local damagecode = DamageInfo()
+            damagecode:SetDamage( collider.DirectDamage)
+            damagecode:SetDamageType( collider.DirectDamageType)
+            damagecode:SetDamagePosition(dmgPos)
+            damagecode:SetAttacker( ( IsValid( owner ) and owner or collider ) )
+            damagecode:SetInflictor( ( IsValid( owner ) and owner or collider ) )
+            
+            self:TakeDamageInfo( damagecode, collider )
         else
             local mass = data.HitObject:GetMass() or 500
             local impactdmg = ( ( data.TheirOldVelocity:Length() * mass ) / 1000 )
@@ -267,7 +282,7 @@ if SERVER then
     local realisticfalldamage = GetConVar( "lambdaplayers_lambda_realisticfalldamage" )
     
     function ENT:OnLandOnGround( ent )
-        if self:IsInNoClip() then return end
+        if self.l_ClimbingLadder or self:IsInNoClip() then return end
         -- Play land animation
         self:AddGesture( ACT_LAND )
 

--- a/lua/lambdaplayers/lambda/sh_util.lua
+++ b/lua/lambdaplayers/lambda/sh_util.lua
@@ -665,12 +665,29 @@ if SERVER then
 
     function ENT:Relations( ent )
         if _LAMBDAPLAYERSEnemyRelations[ ent:GetClass() ] then return D_HT end
+        
+        if ent.IsVJBaseSNPC then
+            if ent.PlayerFriendly then return D_LI end
+            for _, v in ipairs( ent.VJ_NPC_Class ) do if v == "CLASS_PLAYER_ALLY" then return D_LI end end
+            if ent.Behavior == VJ_BEHAVIOR_AGGRESSIVE then return D_HT end
+        end
+
         return D_NU
     end
 
     function ENT:HandleNPCRelations( ent )
         self:DebugPrint( "handling relationship with ", ent )
-        ent:AddEntityRelationship( self , self:Relations( ent ), 1 )
+
+        local relations = self:Relations( ent )
+        ent:AddEntityRelationship( self, relations, 1 )
+
+        if ent.IsVJBaseSNPC and relations == D_HT then
+            self:SimpleTimer( 0.1, function() 
+                if !IsValid( ent ) then return end
+                ent.VJ_AddCertainEntityAsEnemy[ #ent.VJ_AddCertainEntityAsEnemy + 1 ] = self
+                ent.CurrentPossibleEnemies[ #ent.CurrentPossibleEnemies + 1 ] = self
+            end, true )
+        end
     end
 
     function ENT:HandleAllValidNPCRelations()

--- a/lua/lambdaplayers/lambda/sh_x_metarecreations.lua
+++ b/lua/lambdaplayers/lambda/sh_x_metarecreations.lua
@@ -544,7 +544,7 @@ function ENT:GetJumpPower()
 end
 
 function ENT:GetLadderClimbSpeed()
-    return self:GetWalkSpeed()
+    return 200
 end
 
 function ENT:GetLaggedMovementValue()

--- a/lua/lambdaplayers/lambda/sv_states.lua
+++ b/lua/lambdaplayers/lambda/sv_states.lua
@@ -42,10 +42,11 @@ function ENT:Combat()
                 self:UseWeapon( ene )
             end
 
+            local myOrigin = self:GetPos()
             local keepDist = self.l_CombatKeepDistance
-            if keepDist and canSee and self:IsInRange( ene, keepDist ) then
-                local myOrigin = self:GetPos()
-                local potentialPos = ( myOrigin + ( myOrigin - ene:GetPos() ):GetNormalized() * 200 ) + VectorRand( -1000, 1000 )
+            local posCopy = ene:GetPos(); posCopy.z = myOrigin.z
+            if keepDist and canSee and self:IsInRange( posCopy, keepDist ) then
+                local potentialPos = ( myOrigin + ( myOrigin - posCopy ):GetNormalized() * 200 ) + VectorRand( -1000, 1000 )
                 self.l_movepos = ( IsInWorld( potentialPos ) and potentialPos or self:Trace( potentialPos ).HitPos )
             else
                 self.l_movepos = ene

--- a/lua/lambdaplayers/lambda/weapons/hl2_slam.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_slam.lua
@@ -58,7 +58,23 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             hook.Add( "Think", hookID, function()
                 if CurTime() < thinkTime then return end
                 if !IsValid( satchel ) then hook.Remove( "Think", hookID ) return end
-                if !LambdaIsValid( self ) then satchel:Remove(); hook.Remove( "Think", hookID ) return end
+                
+                if !LambdaIsValid( self ) then 
+                    satchel:EmitSound( "Weapon_SLAM.TripMineMode" )
+                    SimpleTimer( RandomFloat( 0.25, 0.5 ), function() 
+                        if !IsValid( satchel ) then return end
+
+                        local effData = EffectData()
+                        effData:SetOrigin( satchel:GetPos() )
+                        EmitEffect( "Explosion", effData, true, true )
+
+                        satchel:Remove()
+                        EmitExplosion( satchel, ( IsValid( self ) and self or satchel ), satchel:WorldSpaceCenter(), 200, 150 )
+                    end )
+
+                    hook.Remove( "Think", hookID ) 
+                    return 
+                end
 
                 for _, v in ipairs( ents.FindInSphere( satchel:GetPos() - ( satchel:GetVelocity() * 0.25 ), RandomInt( 125, 175 ) ) ) do
                     if v == self or v == satchel or !LambdaIsValid( v ) or !v:IsNPC() and !v:IsNextBot() and ( !v:IsPlayer() or !v:Alive() or ignorePlayers:GetBool() ) or !satchel:Visible( v ) then continue end
@@ -76,7 +92,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
                         EmitExplosion( satchel, ( IsValid( self ) and self or satchel ), satchel:WorldSpaceCenter(), 200, 150 )
                     end )
 
-                    thinkTime = CurTime() + 1.0
+                    hook.Remove( "Think", hookID ) 
                     return
                 end
 


### PR DESCRIPTION
 - Added ladder climbing. Same system as Zeta Players one but slightly more polished and optimized.
 - Added basic support for VJ Base. Current issues rn are: human-based SNPCs won't be able to hit Lambda Players with melee attacks and SNPCs will sometimes ignore Lambda Players until attacked by one.
 - Thrown SLAMs now will explode instead of being removed if owner is dead or invalid.