### PR TITLE
Added two new callback functions for weapons

### DIFF
--- a/lua/entities/npc_lambdaplayer.lua
+++ b/lua/entities/npc_lambdaplayer.lua
@@ -154,6 +154,7 @@ function ENT:Initialize()
         self.l_moveWaitTime = 0 -- The time we will wait until continuing moving through our path
         self.l_nextswimposupdate = 0 -- the next time we will update our swimming position
         self.l_ladderfailtimer = CurTime() + 15 -- The time until we are removed and recreated due to Gmod issues with nextbots and ladders. Thanks Facepunch
+        self.l_NextWeaponThink = 0 -- The next time we will run the currenly held weapon's think callback
 
 
         self.l_CurrentPath = nil -- The current path (PathFollower) we are on. If off navmesh, this will hold a Vector
@@ -398,6 +399,15 @@ function ENT:Think()
     hook.Run( "LambdaOnThink", self, self:GetWeaponENT() )
     
     if SERVER then
+        -- Run our weapon's think callback if possible
+        if CurTime() > self.l_NextWeaponThink then
+            local wepThinkFunc = self.l_WeaponThinkFunction
+            if isfunction( wepThinkFunc ) then
+                local thinkTime = wepThinkFunc( self, self:GetWeaponENT() )
+                if isnumber( thinkTime ) then self.l_NextWeaponThink = CurTime() + thinkTime end 
+            end
+        end
+
         if self.l_ispickedupbyphysgun then self.loco:SetVelocity( Vector() ) end
 
         -- Footstep sounds

--- a/lua/lambdaplayers/autorun_includes/client/netmessages.lua
+++ b/lua/lambdaplayers/autorun_includes/client/netmessages.lua
@@ -67,6 +67,7 @@ net.Receive( "lambdaplayers_createclientsidedroppedweapon", function()
     local force = net.ReadVector()
     local offset = net.ReadVector()
     local colvec = net.ReadVector()
+    local wepName = net.ReadString()
 
     if !IsValid( ent ) then return end
 
@@ -79,6 +80,9 @@ net.Receive( "lambdaplayers_createclientsidedroppedweapon", function()
     cs_prop:Spawn()
 
     table_insert( _LAMBDAPLAYERS_ClientSideEnts, cs_prop )
+
+    local dropFunc = _LAMBDAPLAYERSWEAPONS[ wepName ].OnDrop
+    if isfunction( dropFunc ) then dropFunc( cs_prop ) end
 
     local phys = cs_prop:GetPhysicsObject()
 

--- a/lua/lambdaplayers/lambda/sh_hooks.lua
+++ b/lua/lambdaplayers/lambda/sh_hooks.lua
@@ -83,6 +83,7 @@ if SERVER then
                 net.WriteVector( info:GetDamageForce() )
                 net.WriteVector( info:GetDamagePosition() )
                 net.WriteVector( self:GetPhysColor() )
+                net.WriteString( self:GetWeaponName() )
             net.Broadcast()
         end
 

--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -88,6 +88,7 @@ function ENT:SwitchWeapon( weaponname, forceswitch )
     wepent:SetModel( weapondata.model )
     
     
+    self.l_WeaponThinkFunction = weapondata.OnThink
     if isfunction( weapondata.OnEquip ) then weapondata.OnEquip( self, wepent ) end
 
 end

--- a/lua/lambdaplayers/lambda/weapons/hl2_gravitygun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_gravitygun.lua
@@ -15,6 +15,7 @@ local punted = false
 local blastStart, smoothBlast, smoothBlastA = 0, 0, 255
 local blastTarget = false
 local color = Color(255,255,255,255)
+local attachtab = { "fork1m", "fork1t", "fork2m", "fork2t", "fork3m", "fork3t" }
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -28,10 +29,11 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         Draw = function( lambda, wepent )
             if IsValid( wepent ) then
-                local attachtab = { "fork1m", "fork1t", "fork2m", "fork2t", "fork3m", "fork3t" }
-
                 for i = 1, #attachtab do
-                    local at = wepent:GetAttachment( wepent:LookupAttachment( attachtab[i] ) )
+                    local atID = wepent:LookupAttachment( attachtab[i] )
+                    if atID == -1 or atID == 0 then return end
+
+                    local at = wepent:GetAttachment( atID )
                     render.SetMaterial( ggunGlowSprite )
                     render.DrawSprite( at.Pos, 6, 6, Color(255, 128, 0, 64) )
                 end
@@ -48,20 +50,19 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             end
         end,
 
-        OnEquip = function( lambda, wepent )
+        OnThink = function( lambda, wepent )
             -- Pretty much will punt any prop they get close to
-            lambda:Hook( "Think", "GravityGunPuntThink", function( )
-                local find = lambda:FindInSphere( lambda:GetPos(), 150, function( ent ) if !ent:IsNPC() and ent:GetClass()=="prop_physics" and !ent:IsPlayer() and !ent:IsNextBot() and lambda:CanSee( ent ) and IsValid( ent:GetPhysicsObject() ) and lambda:HasPermissionToEdit( ent ) and ent:GetPhysicsObject():IsMoveable() then return true end end )
-                local prop = find[ random( #find ) ]
+            local find = lambda:FindInSphere( lambda:GetPos(), 150, function( ent ) if !ent:IsNPC() and ent:GetClass()=="prop_physics" and !ent:IsPlayer() and !ent:IsNextBot() and lambda:CanSee( ent ) and IsValid( ent:GetPhysicsObject() ) and lambda:HasPermissionToEdit( ent ) and ent:GetPhysicsObject():IsMoveable() then return true end end )
+            local prop = find[ random( #find ) ]
 
-                lambda:LookTo( prop, 3 )
+            lambda:LookTo( prop, 3 )
 
-                lambda:SimpleTimer( 1, function() -- To let the Lambda aim properly
-                    if !IsValid( prop ) or !IsValid( wepent ) then return end
-                    lambda:UseWeapon( prop )
-                end)
-            
-            end, true, 1) -- "Attack" prop twice then do another check (1)
+            lambda:SimpleTimer( 1, function() -- To let the Lambda aim properly
+                if !IsValid( prop ) or !IsValid( wepent ) then return end
+                lambda:UseWeapon( prop )
+            end)
+
+            return 1.0 -- "Attack" prop twice then do another check (1)
         end,
 
         callback = function( self, wepent, target )
@@ -141,11 +142,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             return true
         end,
 
-        OnUnequip = function( lambda, wepent )
-            lambda:RemoveHook( "Think", "GravityGunPuntThink" )
-        end,
-
-        islethal = false,
+        islethal = false
 
     }
 

--- a/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
@@ -17,15 +17,15 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         OnEquip = function( lambda, wepent )
             wepent.CurrentRocket = NULL
-            lambda:Hook( "Think", "LambdaPlayer_OnlyOneRPGRocket", function()
-                if !IsValid( wepent.CurrentRocket ) then return end
-                lambda.l_WeaponUseCooldown = CurTime() + 2.0
-            end, false )
+        end,
+
+        OnThink = function( lambda, wepent )
+            if IsValid( wepent.CurrentRocket ) then lambda.l_WeaponUseCooldown = CurTime() + 2.0 end
+            return 0.1
         end,
 
         OnUnequip = function( lambda, wepent )
             wepent.CurrentRocket = nil
-            lambda:RemoveHook( "Think", "LambdaPlayer_OnlyOneRPGRocket" )
         end,
 
         callback = function( self, wepent, target )            

--- a/lua/lambdaplayers/lambda/weapons/hl2_slam.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_slam.lua
@@ -20,18 +20,18 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         keepdistance = 300,
         attackrange = 400,
 
-        OnEquip = function( self, wepent )
-            self:Hook( "Think", "LambdaSLAM_ThrowRandomly", function()
-                if CurTime() < self.l_WeaponUseCooldown or self:GetState() == "Combat" or RandomInt( 1, 6 ) != 1 then return end
-
+        OnThink = function( self, wepent )
+            if CurTime() > self.l_WeaponUseCooldown and self:GetState() != "Combat" and RandomInt( 1, 6 ) == 1 then
                 local randPos = self:GetRandomPosition( self:WorldSpaceCenter(), 400 )
                 self:LookTo( randPos, 1.5 )
-                
+
                 self:SimpleTimer( 1, function()
                     if self.l_Weapon != "slam" or !IsValid( wepent ) then return end
                     self:UseWeapon( randPos )
                 end )
-            end, false, 1 )
+            end
+
+            return 1.0
         end,
 
         callback = function( self, wepent, target )
@@ -107,10 +107,6 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             wepent:EmitSound( "Weapon_SLAM.SatchelThrow" )
 
             return true
-        end,
-
-        OnUnequip = function( self, wepent )
-            self:RemoveHook( "Think", "LambdaSLAM_ThrowRandomly" )
         end,
 
         islethal = true

--- a/lua/lambdaplayers/lambda/weapons/holster.lua
+++ b/lua/lambdaplayers/lambda/weapons/holster.lua
@@ -34,6 +34,7 @@
     OnEquip         | Function |    A function that will be called when the weapon is equipped  | OPTIONAL
     OnUnequip       | Function |    A function that will be called when the weapon is unequipped    | OPTIONAL
     OnDrop          | Function |    A client side function that will be called when weapon's dropped prop is created | OPTIONAL
+    OnThink         | Function |    A function that runs every tick on server while the weapon is held by Lambda Player. Returning a number in the function will add a cooldown | OPTIONAL
 
 
 
@@ -84,6 +85,7 @@
     OnUnequip       | Function |    A function that will be called when the weapon is unequipped    | OPTIONAL
     OnReload        | Function |    A function that will be called when the weapon's reload is started  | OPTIONAL
     OnDrop          | Function |    A client side function that will be called when weapon's dropped prop is created | OPTIONAL
+    OnThink         | Function |    A function that runs every tick on server while the weapon is held by Lambda Player. Returning a number in the function will add a cooldown | OPTIONAL
 
     ---------------------------------
 ]]

--- a/lua/lambdaplayers/lambda/weapons/holster.lua
+++ b/lua/lambdaplayers/lambda/weapons/holster.lua
@@ -33,6 +33,7 @@
     callback        | Function |    A function that will be called when the weapon is used. Return true if you are making a custom shooting/swinging code   | OPTIONAL
     OnEquip         | Function |    A function that will be called when the weapon is equipped  | OPTIONAL
     OnUnequip       | Function |    A function that will be called when the weapon is unequipped    | OPTIONAL
+    OnDrop          | Function |    A client side function that will be called when weapon's dropped prop is created | OPTIONAL
 
 
 
@@ -82,6 +83,7 @@
     OnEquip         | Function |    A function that will be called when the weapon is equipped  | OPTIONAL
     OnUnequip       | Function |    A function that will be called when the weapon is unequipped    | OPTIONAL
     OnReload        | Function |    A function that will be called when the weapon's reload is started  | OPTIONAL
+    OnDrop          | Function |    A client side function that will be called when weapon's dropped prop is created | OPTIONAL
 
     ---------------------------------
 ]]

--- a/lua/lambdaplayers/lambda/weapons/misc_zombieclaws.lua
+++ b/lua/lambdaplayers/lambda/weapons/misc_zombieclaws.lua
@@ -20,31 +20,33 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         attackrange = 65,
         addspeed = 100,
 
-        -- HP Auto Regen + Leap Attack
         OnEquip = function( lambda, wepent )
-            wepent.NextLeapAttackTime = CurTime()
+            wepent.NextLeapAttackTime = 0
+        end,
 
-            lambda:Hook( "Think", "ZombieClawsThink", function( )
-                if lambda:Health() < lambda:GetMaxHealth() then
-                    lambda:SetHealth( math_min( lambda:Health() + 1, lambda:GetMaxHealth() ) )
-                end
+        -- HP Auto Regen + Leap Attack
+        OnThink = function( lambda, wepent )
+            if lambda:Health() < lambda:GetMaxHealth() then
+                lambda:SetHealth( math_min( lambda:Health() + 1, lambda:GetMaxHealth() ) )
+            end
 
-                if lambda:GetState() == "Combat" and CurTime() > wepent.NextLeapAttackTime then
-                    local target = lambda:GetEnemy()
-                    if LambdaIsValid( target ) then
-                        local distTarget = lambda:GetRangeSquaredTo( target )
-                        if distTarget > ( 300 * 300 ) and distTarget <= ( 600 * 600 ) and lambda.loco:IsOnGround() and lambda:Visible( target ) and target:Visible( lambda ) then
-                            lambda.loco:Jump()
+            if lambda:GetState() == "Combat" and CurTime() > wepent.NextLeapAttackTime then
+                local target = lambda:GetEnemy()
+                if LambdaIsValid( target ) then
+                    local distTarget = lambda:GetRangeSquaredTo( target )
+                    if distTarget > ( 300 * 300 ) and distTarget <= ( 600 * 600 ) and lambda.loco:IsOnGround() and lambda:Visible( target ) and target:Visible( lambda ) then
+                        lambda.loco:Jump()
 
-                            local jumpDir = ( target:GetPos() - lambda:GetPos() ):Angle()
-                            lambda.loco:SetVelocity( jumpDir:Up() * 400 + jumpDir:Forward() * math_min( math_sqrt( distTarget ) * 1.5, 1024 ) )
+                        local jumpDir = ( target:GetPos() - lambda:GetPos() ):Angle()
+                        lambda.loco:SetVelocity( jumpDir:Up() * 400 + jumpDir:Forward() * math_min( math_sqrt( distTarget ) * 1.5, 1024 ) )
 
-                            lambda:EmitSound( "npc/fast_zombie/fz_scream1.wav", 80, lambda:GetVoicePitch() )
-                            wepent.NextLeapAttackTime = CurTime() + 5
-                        end
+                        lambda:EmitSound( "npc/fast_zombie/fz_scream1.wav", 80, lambda:GetVoicePitch() )
+                        wepent.NextLeapAttackTime = CurTime() + 5
                     end
                 end
-            end, false, 0.5)
+            end
+
+            return 0.5
         end,
 
         -- Damage reduction
@@ -53,7 +55,6 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         end,
 
         OnUnequip = function( lambda, wepent )
-            lambda:RemoveHook( "Think", "ZombieClawsThink" )
             wepent.NextLeapAttackTime = nil
         end,
 
@@ -95,7 +96,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             return true
         end,
         
-        islethal = true,
+        islethal = true
     }
 
 })


### PR DESCRIPTION
 - Added `OnThink( lambda, wepent )` server-side function callback that runs in Lambda Player's `ENT:Think()` every tick. Returning a number within the function will add a cooldown to it.
 - Added `OnDrop( cs_prop )` client-side function callback that runs after a clientside dropped weapon's prop is created.
 - Converted most of `self:Hook( "Think" )` and `self:Hook( "Tick" )` functions inside the weapons' `OnEquip` into `OnThink` callbacks.