### PR TITLE
Very tiny fix to avoid error spam when no +voicerecord key in SinglePlayer

### DIFF
--- a/lua/lambdaplayers/autorun_includes/shared/hooks.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/hooks.lua
@@ -99,7 +99,7 @@ elseif CLIENT then
         local limit = false -- This is important so code doesn't run constantly
         hook.Add( "Think", "lambdaplayers_forceenablevoicechat", function()
             local vcbind = input_LookupBinding( "+voicerecord" )
-            local bindenum = input_GetKeyCode( vcbind ) or KEY_X
+            local bindenum = vcbind and input_GetKeyCode( vcbind ) or KEY_X
         
             if input_IsKeyDown( bindenum ) and !limit then
                 limit = true


### PR DESCRIPTION
Why do some people have no key to talk, that's kinda sad :(

resolves #72 