### PR TITLE
Spawning Health / Max Health options, plus more

### DIFF
--- a/lua/entities/npc_lambdaplayer.lua
+++ b/lua/entities/npc_lambdaplayer.lua
@@ -83,6 +83,11 @@ end
     local collisionmins = Vector( -16, -16, 0 )
     local standingcollisionmaxs = Vector( 16, 16, 72 )
     local crouchingcollisionmaxs = Vector( 16, 16, 36 )
+    local maxHealth = GetConVar( "lambdaplayers_lambda_maxhealth" )
+    local spawnHealth = GetConVar( "lambdaplayers_lambda_spawnhealth" )
+    local maxArmor = GetConVar( "lambdaplayers_lambda_maxarmor" )
+    local spawnArmor = GetConVar( "lambdaplayers_lambda_spawnarmor" )
+    local collisionPly = GetConVar( "lambdaplayers_lambda_noplycollisions" )
 --
 
 if CLIENT then
@@ -172,12 +177,12 @@ function ENT:Initialize()
         self:SetLambdaName( self:GetOpenName() )
         self:SetProfilePicture( #Lambdaprofilepictures > 0 and Lambdaprofilepictures[ random( #Lambdaprofilepictures ) ] or "spawnicons/".. sub( self:GetModel(), 1, #self:GetModel() - 4 ).. ".png" )
 
-        self:SetMaxHealth( 100 )
-        self:SetNWMaxHealth( 100 )
-        self:SetHealth( 100 )
+        self:SetMaxHealth( maxHealth:GetInt() )
+        self:SetNWMaxHealth( maxHealth:GetInt() )
+        self:SetHealth( spawnHealth:GetInt() )
 
-        self:SetArmor( 0 ) -- Our current armor
-        self:SetMaxArmor( 100 ) -- Our maximum armor
+        self:SetArmor( spawnArmor:GetInt() ) -- Our current armor
+        self:SetMaxArmor( maxArmor:GetInt() ) -- Our maximum armor
 
         self:SetPlyColor( Vector( random( 255 ) / 225, random( 255 ) / 255, random( 255 ) / 255 ) )
         self:SetPhysColor( Vector( random( 255 ) / 225, random( 255 ) / 255, random( 255 ) / 255 ) )
@@ -241,7 +246,13 @@ function ENT:Initialize()
 
         self:SetCollisionBounds( collisionmins, standingcollisionmaxs )
         self:PhysicsInitShadow()
-        self:SetCollisionGroup( COLLISION_GROUP_PLAYER )
+
+        if !collisionPly:GetBool() then
+            self:SetCollisionGroup( COLLISION_GROUP_PLAYER )
+        else
+            self:SetCollisionGroup(COLLISION_GROUP_PASSABLE_DOOR)
+        end
+
         self:SetSolidMask( MASK_PLAYERSOLID )
         self:AddCallback( "PhysicsCollide", function( self, data )
             self:HandleCollision( data )

--- a/lua/lambdaplayers/autorun_includes/shared/convars.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/convars.lua
@@ -164,6 +164,7 @@ CreateLambdaConvar( "lambdaplayers_text_sentencemixing", 0, true, false, false, 
 
 -- Force Related Convars
 CreateLambdaConvar( "lambdaplayers_force_radius", 750, true, false, false, "The Distance for which Lambda Players are affected by Force Menu options.", 250, 25000, { type = "Slider", name = "Force Radius", decimals = 0, category = "Force Menu" } )
+CreateLambdaConvar( "lambdaplayers_force_spawnbehavior", 0, true, false, false, "Lambda Players behavior when spawned via Force Menu. 0 - Nothing, 1 - Attack you, 2 - Attack random Lambda/NPC", 0 , 2, { type = "Slider", decimals = 0, name = "Behavior", category = "Force Menu" } )
 CreateLambdaConvar( "lambdaplayers_lambda_spawnatplayerspawns", 0, true, false, false, "If spawned Lambda Players should spawn at player spawn points", 0, 1, { type = "Bool", name = "Spawn at Player Spawns", category = "Force Menu" } )
 --
 

--- a/lua/lambdaplayers/autorun_includes/shared/convars.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/convars.lua
@@ -101,6 +101,10 @@ CreateLambdaColorConvar( "lambdaplayers_displaycolor", Color( 255, 136, 0 ), tru
 
 -- Lambda Player Server Convars
 CreateLambdaConvar( "lambdaplayers_lambda_infwanderdistance", 0, true, false, false, "If Lambda Players should be able to walk anywhere on the navmesh instead of only walking within 1500 source units", 0, 1, { type = "Bool", name = "Unlimited Walk Distance", category = "Lambda Server Settings" } )
+CreateLambdaConvar( "lambdaplayers_lambda_maxhealth", 100, true, false, false, "Max Lamda Player Health", 1, 10000, { type = "Slider", decimals = 0, name = "Max Health", category = "Lambda Server Settings" } )
+CreateLambdaConvar( "lambdaplayers_lambda_spawnhealth", 100, true, false, false, "The amount of health Lambda Players will spawn with", 1, 10000, { type = "Slider", decimals = 0, name = "Spawning Health", category = "Lambda Server Settings" } )
+CreateLambdaConvar( "lambdaplayers_lambda_maxarmor", 100, true, false, false, "Max Lambda Player Armor", 0, 10000, { type = "Slider", decimals = 0, name = "Max Armor", category = "Lambda Server Settings" } )
+CreateLambdaConvar( "lambdaplayers_lambda_spawnarmor", 0, true, false, false, "The amount of armor Lambda Players will spawn with", 0, 10000, { type = "Slider", decimals = 0, name = "Spawning Armor", category = "Lambda Server Settings" } )
 CreateLambdaConvar( "lambdaplayers_lambda_allownoclip", 1, true, false, false, "If Lambda Players are allowed to Noclip", 0, 1, { type = "Bool", name = "Allow Noclip", category = "Lambda Server Settings" } )
 CreateLambdaConvar( "lambdaplayers_lambda_allowkillbind", 0, true, false, false, "If Lambda Players are allowed to randomly use their Killbind", 0, 1, { type = "Bool", name = "Allow Killbind", category = "Lambda Server Settings" } )
 CreateLambdaConvar( "lambdaplayers_lambda_allowrandomaddonsmodels", 0, true, false, false, "If Lambda Players can use random addon playermodels", 0, 1, { type = "Bool", name = "Addon Playermodels", category = "Lambda Server Settings" } )
@@ -117,6 +121,7 @@ CreateLambdaConvar( "lambdaplayers_lambda_obeynavmeshattributes", 0, true, false
 CreateLambdaConvar( "lambdaplayers_lambda_overridegamemodehooks", 1, true, false, false, "If the addon is allowed to override the following GAMEMODE hooks to support Lambda Players: GM:PlayerDeath() GM:PlayerStartVoice() GM:PlayerEndVoice() GM:OnNPCKilled() Default SandBox Scoreboard : Changing this requires you to restart the server/game for the changes to apply!", 0, 1, { type = "Bool", name = "Override Gamemode Hooks", category = "Lambda Server Settings" } )
 CreateLambdaConvar( "lambdaplayers_lambda_callonnpckilledhook", 0, true, false, false, "If killed Lambda Players should call the OnNPCKilled hook. Best used with the Override Gamemode Hooks option!", 0, 1, { type = "Bool", name = "Call OnNPCKilled Hook On Death", category = "Lambda Server Settings" } )
 CreateLambdaConvar( "lambdaplayers_lambda_singleplayerthinkdelay", 0, true, false, false, "The amount of seconds Lambda Players will execute their next Think. 0.1 is a good value. Increasing this will increase performance at the cost of delays and decreasing this may decrease performance but have less delays. This only applies to singleplayer since multiplayer automatically adjusts think time", 0, 0.24, { type = "Slider", decimals = 2, name = "Think Delay", category = "Lambda Server Settings" } )
+CreateLambdaConvar( "lambdaplayers_lambda_noplycollisions", 0, true, false, false, "If Lambda Players can pass through players (Useful in small corridors/areas)", 0, 1, { type = "Bool", name = "Disable Player Collisions", category = "Lambda Server Settings" } )
 //CreateLambdaConvar( "lambdaplayers_lambda_useserversideragdolls", 0, true, false, false, "If Lambda Players corpses should be Server-Side", 0, 1, { type = "Bool", name = "Server-Side Corpses", category = "Lambda Server Settings" } )
 --
 
@@ -164,7 +169,7 @@ CreateLambdaConvar( "lambdaplayers_text_sentencemixing", 0, true, false, false, 
 
 -- Force Related Convars
 CreateLambdaConvar( "lambdaplayers_force_radius", 750, true, false, false, "The Distance for which Lambda Players are affected by Force Menu options.", 250, 25000, { type = "Slider", name = "Force Radius", decimals = 0, category = "Force Menu" } )
-CreateLambdaConvar( "lambdaplayers_force_spawnbehavior", 0, true, false, false, "Lambda Players behavior when spawned via Force Menu. 0 - Nothing, 1 - Attack you, 2 - Attack random Lambda/NPC", 0 , 2, { type = "Slider", decimals = 0, name = "Behavior", category = "Force Menu" } )
+CreateLambdaConvar( "lambdaplayers_force_spawnbehavior", 0, true, false, false, "Lambda Players behavior when spawned via Force Menu. 0 - Nothing, 1 - Attack you, 2 - Attack random Lambda/NPC", 0 , 2, { type = "Slider", decimals = 0, name = "Spawn Behavior Modifier", category = "Force Menu" } )
 CreateLambdaConvar( "lambdaplayers_lambda_spawnatplayerspawns", 0, true, false, false, "If spawned Lambda Players should spawn at player spawn points", 0, 1, { type = "Bool", name = "Spawn at Player Spawns", category = "Force Menu" } )
 --
 

--- a/lua/lambdaplayers/autorun_includes/shared/d_consolecommands.lua
+++ b/lua/lambdaplayers/autorun_includes/shared/d_consolecommands.lua
@@ -5,6 +5,8 @@ local ipairs = ipairs
 local random = math.random
 local IsValid = IsValid
 local distance = GetConVar( "lambdaplayers_force_radius" )
+local spawnatplayerpoints = GetConVar( "lambdaplayers_lambda_spawnatplayerspawns" )
+local LambdaSpawnBehavior = GetConVar( "lambdaplayers_force_spawnbehavior" )
 
 
 -- The reason this lua file has a d_ in its filename is because of the order on how lua files are loaded.
@@ -133,6 +135,13 @@ CreateLambdaConsoleCommand( "lambdaplayers_cmd_forcespawnlambda", function( ply 
 	lambda:SetAngles( Angle( 0, random( 0, 360, 0 ), 0 ) )
 	lambda:Spawn()
 
+	if LambdaSpawnBehavior:GetInt() == 1 then
+		lambda:AttackTarget( ply )
+	elseif LambdaSpawnBehavior:GetInt() == 2 then
+		local npcs = lambda:FindInSphere( nil, 25000, function( ent ) return ( ent:IsNPC() or ent:IsNextBot() ) end )
+		lambda:AttackTarget( npcs[ random( #npcs ) ] )
+	end
+
 	undo.Create( "Lambda Player ( " .. lambda:GetLambdaName() .. " )" )
 		undo.SetPlayer( ply )
 		undo.SetCustomUndoText( "Undone " .. "Lambda Player ( " .. lambda:GetLambdaName() .. " )" )
@@ -166,12 +175,12 @@ CreateLambdaConsoleCommand( "lambdaplayers_cmd_forcecombatlambda", function( ply
 
     for k, v in ipairs( ents_FindInSphere( ply:GetPos(), distance:GetInt() ) ) do
         if IsValid( v ) and v.IsLambdaPlayer then
-			local npcs = v:FindInSphere( nil, 25000, function( ent ) return ( ent:IsNPC() or ent:IsNextBot() ) end)
+			local npcs = v:FindInSphere( nil, 25000, function( ent ) return ( ent:IsNPC() or ent:IsNextBot() ) end )
 			v:AttackTarget( npcs[ random( #npcs ) ] )
 		end
     end
 
-end, false, "Forces all Lambda Players attack anything", { name = "Lambda Players Attack Anything", category = "Force Menu" } )
+end, false, "Forces all Lambda Players to attack anything", { name = "Lambda Players Attack Anything", category = "Force Menu" } )
 
 CreateLambdaConsoleCommand( "lambdaplayers_cmd_forcekill", function( ply ) 
     if IsValid( ply ) and !ply:IsSuperAdmin() then return end


### PR DESCRIPTION
• Added a returning feature from Zeta Players that is expanded upon for Lambda's.
- Max Health
- Spawning Health
- Max Armor
- Spawning Armor

Max Health / Max Armor will set the Lambda's maximum amount for Health / Armor.
Spawning Health / Spawning Armor will set the Lambda's current amount for Health / Armor.

• Added "No Player Collision" command, this is useful for small maps, or if you're sick of getting stuck on Lambda's.

• Added a new Force option, "Spawn Behavior Modifier". Only applies to Lambda's spawned via `lambdaplayers_cmd_forcespawnlambda`. 

When Lambda Players get spawned in via the command, have them do something upon spawning. `0 - Normal state (Nothing happens), 1 - Attack you, 2 - Attack random NPC/Lambda.`

• Minor `end` space fix in `lambdaplayers_cmd_forcecombatlambda`