### PR TITLE
LambdaKillFeedAdd now uses Lambda Player's team variable

### DIFF
--- a/lua/lambdaplayers/autorun_includes/client/netmessages.lua
+++ b/lua/lambdaplayers/autorun_includes/client/netmessages.lua
@@ -111,8 +111,11 @@ net.Receive( "lambdaplayers_createclientsidedroppedweapon", function()
         net.SendToServer()
 
         net.Receive( "lambdaplayers_server_sendpos", function()
+            if !IsValid( cs_prop ) then return end
+
             local svPos = net.ReadVector()
             if !svPos then cs_prop:Remove() return end
+
             cs_prop:SetPos( svPos )
         end )
     else

--- a/lua/lambdaplayers/autorun_includes/server/globals.lua
+++ b/lua/lambdaplayers/autorun_includes/server/globals.lua
@@ -498,8 +498,8 @@ function LambdaKillFeedAdd( victim, attacker, inflictor )
     local attackername = attacker.IsLambdaPlayer and attacker:GetLambdaName() or attacker.IsZetaPlayer and attacker.zetaname or attacker:IsPlayer() and attacker:Name() or "#" .. attacker:GetClass()
     local victimname = victim.IsLambdaPlayer and victim:GetLambdaName() or victim.IsZetaPlayer and victim.zetaname or victim:IsPlayer() and victim:Name() or "#" .. victim:GetClass()
     local inflictorname = IsValid( inflictor ) and ( ( inflictor.IsLambdaWeapon and inflictor.l_killiconname ) or ( inflictor == attacker and IsValid( attacker ) and attacker.GetActiveWeapon and IsValid( attacker:GetActiveWeapon() ) and attacker:GetActiveWeapon():GetClass() ) or IsValid( inflictor ) and inflictor:GetClass() ) or "suicide"
-    local attackerteam = attacker.IsLambdaPlayer and 0 or attacker:IsPlayer() and attacker:Team() or -1
-    local victimteam = victim.IsLambdaPlayer and 0 or victim:IsPlayer() and victim:Team() or -1
+    local attackerteam = attacker.IsLambdaPlayer and victim:GetTeam() or attacker:IsPlayer() and attacker:Team() or -1
+    local victimteam = victim.IsLambdaPlayer and victim:GetTeam() or victim:IsPlayer() and victim:Team() or -1
 
     net.Start( "lambdaplayers_addtokillfeed" )
         net.WriteString( attackername )

--- a/lua/lambdaplayers/autorun_includes/server/globals.lua
+++ b/lua/lambdaplayers/autorun_includes/server/globals.lua
@@ -498,8 +498,8 @@ function LambdaKillFeedAdd( victim, attacker, inflictor )
     local attackername = attacker.IsLambdaPlayer and attacker:GetLambdaName() or attacker.IsZetaPlayer and attacker.zetaname or attacker:IsPlayer() and attacker:Name() or "#" .. attacker:GetClass()
     local victimname = victim.IsLambdaPlayer and victim:GetLambdaName() or victim.IsZetaPlayer and victim.zetaname or victim:IsPlayer() and victim:Name() or "#" .. victim:GetClass()
     local inflictorname = IsValid( inflictor ) and ( ( inflictor.IsLambdaWeapon and inflictor.l_killiconname ) or ( inflictor == attacker and IsValid( attacker ) and attacker.GetActiveWeapon and IsValid( attacker:GetActiveWeapon() ) and attacker:GetActiveWeapon():GetClass() ) or IsValid( inflictor ) and inflictor:GetClass() ) or "suicide"
-    local attackerteam = attacker.IsLambdaPlayer and victim:GetTeam() or attacker:IsPlayer() and attacker:Team() or -1
-    local victimteam = victim.IsLambdaPlayer and victim:GetTeam() or victim:IsPlayer() and victim:Team() or -1
+    local attackerteam = ( attacker.IsLambdaPlayer and attacker:GetTeam() or ( attacker:IsPlayer() and attacker:Team() or 1001 ) )
+    local victimteam = ( victim.IsLambdaPlayer and victim:GetTeam() or ( victim:IsPlayer() and victim:Team() or 1001 ) )
 
     net.Start( "lambdaplayers_addtokillfeed" )
         net.WriteString( attackername )


### PR DESCRIPTION
I needed to do this for the killfeed's color in team system module to work.